### PR TITLE
ci: branch that triggers ci is changed from master to main

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,9 +3,9 @@ name: CI
 # Triggers the workflow on push or pull request events but only for the master branch
 on:
     push:
-        branches: [master]
+        branches: [main]
     pull_request:
-        branches: [master]
+        branches: [main]
 
 jobs:
     setup:


### PR DESCRIPTION
## 简介
触发 github ci 的分支，从 master 修改为 main