### PR TITLE
Feat/optimize basic parser

### DIFF
--- a/src/parser/common/basicParser.ts
+++ b/src/parser/common/basicParser.ts
@@ -51,19 +51,19 @@ export default abstract class BasicParser<
     /**
      * preferredRules for antlr4-c3
      */
-    public abstract preferredRules: Set<number>;
+    protected abstract preferredRules: Set<number>;
  
     /**
      * Create antrl4 Lexer instance
      * @param input source string
      */
-    public abstract createLexerFormCharStream(charStreams: CodePointCharStream): L;
+    protected abstract createLexerFormCharStream(charStreams: CodePointCharStream): L;
 
     /**
      * Create Parser by CommonTokenStream
      * @param tokenStream CommonTokenStream
      */
-    public abstract createParserFromTokenStream(tokenStream: CommonTokenStream): P;
+    protected abstract createParserFromTokenStream(tokenStream: CommonTokenStream): P;
     
     /**
      * convert candidates to suggestions
@@ -73,7 +73,7 @@ export default abstract class BasicParser<
      * @param tokenIndexOffset offset of the tokenIndex in the candidates 
      * compared to the tokenIndex in allTokens
      */
-    public abstract processCandidates(
+    protected abstract processCandidates(
         candidates: CandidatesCollection, 
         allTokens: Token[], 
         caretTokenIndex: number,

--- a/src/parser/common/basicParser.ts
+++ b/src/parser/common/basicParser.ts
@@ -292,6 +292,7 @@ export default abstract class BasicParser<
                     const tokenStream = new CommonTokenStream(lexer);
                     tokenStream.fill();
                     const parser = this.createParserFromTokenStream(tokenStream);
+                    parser.removeErrorListeners();
                     parser.buildParseTree = true;
                     sqlParserIns = parser;
                     c3Context = parser.program();

--- a/src/parser/flinksql.ts
+++ b/src/parser/flinksql.ts
@@ -12,17 +12,17 @@ import { SyntaxContextType, Suggestions, SyntaxSuggestion } from './common/basic
 import BasicParser from './common/basicParser';
 
 export default class FlinkSQL extends BasicParser<FlinkSqlLexer, ProgramContext, FlinkSqlParser> {
-    public createLexerFormCharStream(charStreams) {
+    protected createLexerFormCharStream(charStreams) {
         const lexer = new FlinkSqlLexer(charStreams);
         return lexer;
     }
 
-    public createParserFromTokenStream(tokenStream) {
+    protected createParserFromTokenStream(tokenStream) {
         const parser = new FlinkSqlParser(tokenStream);
         return parser;
     }
 
-    public preferredRules = new Set([
+    protected preferredRules = new Set([
         FlinkSqlParser.RULE_tablePath, // table name >> select / insert ...
         FlinkSqlParser.RULE_tablePathCreate, // table name >> create 
         FlinkSqlParser.RULE_databasePath, // database name >> show
@@ -34,7 +34,7 @@ export default class FlinkSQL extends BasicParser<FlinkSqlLexer, ProgramContext,
         return new FlinkSqlSplitListener();
     }
 
-    public processCandidates(
+    protected processCandidates(
         candidates: CandidatesCollection,
         allTokens: Token[],
         caretTokenIndex: number,

--- a/src/parser/generic.ts
+++ b/src/parser/generic.ts
@@ -6,22 +6,22 @@ import BasicParser from './common/basicParser';
 import { Suggestions } from './common/basic-parser-types';
 
 export default class GenericSQL extends BasicParser<SqlLexer, ProgramContext, SqlParser> {
-    public createLexerFormCharStream(charStreams): SqlLexer {
+    protected createLexerFormCharStream(charStreams): SqlLexer {
         const lexer = new SqlLexer(charStreams);
         return lexer;
     }
 
-    public createParserFromTokenStream(tokenStream): SqlParser {
+    protected createParserFromTokenStream(tokenStream): SqlParser {
         return new SqlParser(tokenStream);
     }
 
-    public preferredRules: Set<number> = new Set();
+    protected preferredRules: Set<number> = new Set();
 
     protected get splitListener () {
         return null as any;
     }
 
-    public processCandidates(
+    protected processCandidates(
         candidates: CandidatesCollection, 
         allTokens: Token[], 
         caretTokenIndex: number

--- a/src/parser/hive.ts
+++ b/src/parser/hive.ts
@@ -7,12 +7,12 @@ import { Suggestions } from './common/basic-parser-types';
 
 
 export default class HiveSQL extends BasicParser<HiveSqlLexer, ProgramContext, HiveSql> {
-    public createLexerFormCharStream(charStreams) {
+    protected createLexerFormCharStream(charStreams) {
         const lexer = new HiveSqlLexer(charStreams);
         return lexer;
     }
 
-    public createParserFromTokenStream(tokenStream) {
+    protected createParserFromTokenStream(tokenStream) {
         return new HiveSql(tokenStream);
     }
 
@@ -20,9 +20,9 @@ export default class HiveSQL extends BasicParser<HiveSqlLexer, ProgramContext, H
         return null as any;
     }
 
-    public preferredRules: Set<number> = new Set();
+    protected preferredRules: Set<number> = new Set();
 
-    public processCandidates(
+    protected processCandidates(
         candidates: CandidatesCollection, 
         allTokens: Token[], 
         caretTokenIndex: number

--- a/src/parser/pgsql.ts
+++ b/src/parser/pgsql.ts
@@ -6,22 +6,22 @@ import BasicParser from './common/basicParser';
 import { Suggestions } from './common/basic-parser-types';
 
 export default class PostgresSQL extends BasicParser<PostgreSQLLexer, ProgramContext, PostgreSQLParser> {
-    public createLexerFormCharStream(charStreams) {
+    protected createLexerFormCharStream(charStreams) {
         const lexer = new PostgreSQLLexer(charStreams);
         return lexer;
     }
 
-    public createParserFromTokenStream(tokenStream) {
+    protected createParserFromTokenStream(tokenStream) {
         return new PostgreSQLParser(tokenStream);
     }
 
-    public preferredRules: Set<number> = new Set();
+    protected preferredRules: Set<number> = new Set();
 
     protected get splitListener () {
         return null as any;
     }
 
-    public processCandidates(
+    protected processCandidates(
         candidates: CandidatesCollection, 
         allTokens: Token[], 
         caretTokenIndex: number

--- a/src/parser/plsql.ts
+++ b/src/parser/plsql.ts
@@ -6,22 +6,22 @@ import BasicParser from './common/basicParser';
 import { Suggestions } from './common/basic-parser-types';
 
 export default class PLSQL extends BasicParser<PlSqlLexer, ProgramContext, PlSqlParser> {
-    public createLexerFormCharStream(charStreams) {
+    protected createLexerFormCharStream(charStreams) {
         const lexer = new PlSqlLexer(charStreams);
         return lexer;
     }
 
-    public createParserFromTokenStream(tokenStream) {
+    protected createParserFromTokenStream(tokenStream) {
         return new PlSqlParser(tokenStream);
     }
 
-    public preferredRules: Set<number> = new Set();
+    protected preferredRules: Set<number> = new Set();
 
     protected get splitListener () {
         return null as any;
     }
 
-    public processCandidates(
+    protected processCandidates(
         candidates: CandidatesCollection, 
         allTokens: Token[], 
         caretTokenIndex: number

--- a/src/parser/spark.ts
+++ b/src/parser/spark.ts
@@ -6,22 +6,22 @@ import BasicParser from './common/basicParser';
 import { Suggestions } from './common/basic-parser-types';
 
 export default class SparkSQL extends BasicParser<SparkSqlLexer, ProgramContext, SparkSqlParser> {
-    public createLexerFormCharStream(charStreams) {
+    protected createLexerFormCharStream(charStreams) {
         const lexer = new SparkSqlLexer(charStreams);
         return lexer;
     }
 
-    public createParserFromTokenStream(tokenStream) {
+    protected createParserFromTokenStream(tokenStream) {
         return new SparkSqlParser(tokenStream);
     }
 
-    public preferredRules: Set<number> = new Set();
+    protected preferredRules: Set<number> = new Set();
 
     protected get splitListener () {
         return null as any;
     }
 
-    public processCandidates(
+    protected processCandidates(
         candidates: CandidatesCollection, 
         allTokens: Token[], 
         caretTokenIndex: number

--- a/src/parser/trinosql.ts
+++ b/src/parser/trinosql.ts
@@ -6,12 +6,12 @@ import BasicParser from './common/basicParser';
 import { Suggestions } from './common/basic-parser-types';
 
 export default class TrinoSQL extends BasicParser<TrinoSqlLexer, ProgramContext, TrinoSqlParser> {
-    public createLexerFormCharStream(charStreams) {
+    protected createLexerFormCharStream(charStreams) {
         const lexer = new TrinoSqlLexer(charStreams);
         return lexer;
     }
 
-    public createParserFromTokenStream(tokenStream) {
+    protected createParserFromTokenStream(tokenStream) {
         const parser = new TrinoSqlParser(tokenStream);
         return parser;
     }
@@ -20,9 +20,9 @@ export default class TrinoSQL extends BasicParser<TrinoSqlLexer, ProgramContext,
         return null as any;
     }
 
-    public preferredRules: Set<number> = new Set();
+    protected preferredRules: Set<number> = new Set();
 
-    public processCandidates(
+    protected processCandidates(
         candidates: CandidatesCollection, 
         allTokens: Token[], 
         caretTokenIndex: number


### PR DESCRIPTION
## 简介
优化 basic-parser 类

## 主要变更
+ 将一些basicParser 内部使用的方法设置为 protected
+ 新增 createParser 和 createLexer 并设置为 public
+ 原来的 createParser 方法更名为 createParserWithCache 并设置为 protected 
+ splitSQL 方法更名为 splitSQLByStatement
+ 在自动补全方法内部解析sql时移除内置的 errorListeners （不打印语法错误信息）