### PR TITLE
Refactor/basic parser

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-    '*.js|ts': [`prettier --write`],
+    '*.js': [`prettier --write`],
+    '*.ts': [`prettier --write`],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,4 @@ export * from './lib/trinosql/TrinoSqlVisitor';
 export { SyntaxContextType } from './parser/common/basic-parser-types';
 
 export type * from './parser/common/basic-parser-types';
-export type { SyntaxError, ParseError } from './parser/common/parseErrorListener';
+export type { SyntaxError, ParseError, ErrorHandler } from './parser/common/parseErrorListener';

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,4 @@ export * from './lib/trinosql/TrinoSqlVisitor';
 export { SyntaxContextType } from './parser/common/basic-parser-types';
 
 export type * from './parser/common/basic-parser-types';
-export type { SyntaxError, ParserError } from './parser/common/parserErrorListener';
+export type { SyntaxError, ParseError } from './parser/common/parseErrorListener';

--- a/src/parser/common/basic-parser-types.ts
+++ b/src/parser/common/basic-parser-types.ts
@@ -71,10 +71,13 @@ export interface Suggestions<T = WordRange> {
 }
 
 export interface TextSlice {
+    /** start at 0 */
     startIndex: number;
     endIndex: number;
+    /** start at 1 */
     startLine: number;
     endLine: number;
+    /** start at 1 */
     startColumn: number;
     endColumn: number;
     text: string;

--- a/src/parser/common/basicParser.ts
+++ b/src/parser/common/basicParser.ts
@@ -214,7 +214,7 @@ export default abstract class BasicParser<
         this.parse(input);
         const splitListener = this.splitListener;
         // TODO: add splitListener to all sqlParser implements add remove following if
-        if (splitListener) return null;
+        if (!splitListener) return null;
 
         this.listen(splitListener, this._parserTree);
 

--- a/src/parser/common/basicParser.ts
+++ b/src/parser/common/basicParser.ts
@@ -43,11 +43,10 @@ export default abstract class BasicParser<
     protected _parser: P;
     protected _parseTree: PRC;
     protected _parsedInput: string = null;
-    protected _parseErrors: ParseError[];
+    protected _parseErrors: ParseError[] = [];
     /** members for cache end */
 
     private _errorHandler: ErrorHandler<any> = (error) => {
-        debugger;
         this._parseErrors.push(error);
     };
 
@@ -97,7 +96,7 @@ export default abstract class BasicParser<
         const lexer = this.createLexerFormCharStream(charStreams);
         if(errorListener) {
             lexer.removeErrorListeners();
-            lexer.addErrorListener(new ParseErrorListener(this._errorHandler));
+            lexer.addErrorListener(new ParseErrorListener(errorListener));
         }
         return lexer;
     }
@@ -113,7 +112,7 @@ export default abstract class BasicParser<
 
         if(errorListener) {
             parser.removeErrorListeners();
-            parser.addErrorListener(new ParseErrorListener(this._errorHandler));
+            parser.addErrorListener(new ParseErrorListener(errorListener));
         }
 
         return parser;

--- a/src/parser/common/basicParser.ts
+++ b/src/parser/common/basicParser.ts
@@ -195,23 +195,6 @@ export default abstract class BasicParser<
     }
 
     /**
-     * It convert tree to string, it's convenient to use in unit test.
-     * @param string input
-     */
-    public parserTreeToString(input: string): string {
-        this.parse(input);
-        return this._parserTree.toStringTree(this._parser.ruleNames);
-    }
-
-    /**
-     * Get List-like style tree string
-     * @param parserTree ProgramRuleContext
-     */
-    public toString(parserTree: PRC): string {
-        return parserTree.toStringTree(this._parser.ruleNames);
-    }
-
-    /**
      * @param listener Listener instance extends ParserListener
      * @param parserTree parser Tree
      */

--- a/src/parser/common/basicParser.ts
+++ b/src/parser/common/basicParser.ts
@@ -50,7 +50,6 @@ export default abstract class BasicParser<
         this._parseErrors.push(error);
     };
 
-
     /**
      * PreferredRules for antlr4-c3
      */
@@ -94,7 +93,7 @@ export default abstract class BasicParser<
     public createLexer(input: string, errorListener?: ErrorHandler<any>) {
         const charStreams = CharStreams.fromString(input.toUpperCase());
         const lexer = this.createLexerFormCharStream(charStreams);
-        if(errorListener) {
+        if (errorListener) {
             lexer.removeErrorListeners();
             lexer.addErrorListener(new ParseErrorListener(errorListener));
         }
@@ -110,7 +109,7 @@ export default abstract class BasicParser<
         const tokenStream = new CommonTokenStream(lexer);
         const parser = this.createParserFromTokenStream(tokenStream);
 
-        if(errorListener) {
+        if (errorListener) {
             parser.removeErrorListeners();
             parser.addErrorListener(new ParseErrorListener(errorListener));
         }
@@ -224,8 +223,8 @@ export default abstract class BasicParser<
      * @param input source string
      */
     public splitSQLByStatement(input): TextSlice[] {
-        const errors =  this.validate(input);
-        if(errors.length) {
+        const errors = this.validate(input);
+        if (errors.length) {
             return null;
         }
         const splitListener = this.splitListener;

--- a/src/parser/common/parseErrorListener.ts
+++ b/src/parser/common/parseErrorListener.ts
@@ -1,7 +1,10 @@
-import { Token, Recognizer, ParserErrorListener, RecognitionException } from 'antlr4ts';
+import { Token, Recognizer, ANTLRErrorListener, RecognitionException } from 'antlr4ts';
 import { ATNSimulator } from 'antlr4ts/atn/ATNSimulator';
 
-export interface ParserError {
+/**
+ * Converted from {@link SyntaxError}.
+ */
+export interface ParseError {
     startLine: number;
     endLine: number;
     startCol: number;
@@ -9,6 +12,9 @@ export interface ParserError {
     message: string;
 }
 
+/**
+ * The type of error resulting from lexical parsing and parsing.
+ */
 export interface SyntaxError<T> {
     recognizer: Recognizer<T, ATNSimulator>;
     offendingSymbol: Token;
@@ -18,9 +24,13 @@ export interface SyntaxError<T> {
     e: RecognitionException;
 }
 
-export type ErrorHandler<T> = (err: ParserError, originalError: SyntaxError<T>) => void;
+/**
+ * ErrorHandler will be invoked when it encounters a parsing error.
+ * Includes lexical errors and parsing errors.
+ */
+export type ErrorHandler<T> = (parseError: ParseError, originalError: SyntaxError<T>) => void;
 
-export default class CustomParserErrorListener implements ParserErrorListener {
+export default class ParseErrorListener implements ANTLRErrorListener<Token> {
     private _errorHandler;
 
     constructor(errorListener: ErrorHandler<Token>) {

--- a/src/parser/common/parserErrorListener.ts
+++ b/src/parser/common/parserErrorListener.ts
@@ -18,51 +18,7 @@ export interface SyntaxError<T> {
     e: RecognitionException;
 }
 
-export type ErrorHandler<T> = (err: ParserError, errOption: SyntaxError<T>) => void;
-
-export class ParserErrorCollector implements ParserErrorListener {
-    private _parseErrors: ParserError[] = [];
-    private _syntaxErrors: SyntaxError<Token>[] = [];
-
-    syntaxError(
-        recognizer: Recognizer<Token, ATNSimulator>,
-        offendingSymbol: Token,
-        line: number,
-        charPositionInLine: number,
-        msg: string,
-        e: RecognitionException
-    ) {
-        let endCol = charPositionInLine + 1;
-        if (offendingSymbol && offendingSymbol.text !== null) {
-            endCol = charPositionInLine + (offendingSymbol.text?.length ?? 0);
-        }
-        this._parseErrors.push({
-            startLine: line,
-            endLine: line,
-            startCol: charPositionInLine,
-            endCol: endCol,
-            message: msg,
-        });
-
-        this._syntaxErrors.push({
-            e,
-            line,
-            msg,
-            recognizer,
-            offendingSymbol,
-            charPositionInLine,
-        });
-    }
-
-    clear() {
-        this._parseErrors = [];
-        this._syntaxErrors = [];
-    }
-
-    get parserErrors() {
-        return this._parseErrors;
-    }
-}
+export type ErrorHandler<T> = (err: ParserError, originalError: SyntaxError<T>) => void;
 
 export default class CustomParserErrorListener implements ParserErrorListener {
     private _errorHandler;
@@ -73,7 +29,7 @@ export default class CustomParserErrorListener implements ParserErrorListener {
 
     syntaxError(
         recognizer: Recognizer<Token, ATNSimulator>,
-        offendingSymbol: Token,
+        offendingSymbol,
         line: number,
         charPositionInLine: number,
         msg: string,

--- a/src/parser/hive.ts
+++ b/src/parser/hive.ts
@@ -1,11 +1,7 @@
 import { Token } from 'antlr4ts';
 import { CandidatesCollection } from 'antlr4-c3';
 import { HiveSqlLexer } from '../lib/hive/HiveSqlLexer';
-import {
-    HiveSqlParser,
-    ProgramContext,
-    StatementContext,
-} from '../lib/hive/HiveSqlParser';
+import { HiveSqlParser, ProgramContext, StatementContext } from '../lib/hive/HiveSqlParser';
 import BasicParser from './common/basicParser';
 import { HiveSqlParserListener } from '../lib/hive/HiveSqlParserListener';
 import { SyntaxContextType, Suggestions, SyntaxSuggestion } from './common/basic-parser-types';

--- a/src/parser/hive.ts
+++ b/src/parser/hive.ts
@@ -5,8 +5,6 @@ import {
     HiveSqlParser,
     ProgramContext,
     StatementContext,
-    ExplainStatementContext,
-    ExecStatementContext,
 } from '../lib/hive/HiveSqlParser';
 import BasicParser from './common/basicParser';
 import { HiveSqlParserListener } from '../lib/hive/HiveSqlParserListener';

--- a/test/common/basicParser.test.ts
+++ b/test/common/basicParser.test.ts
@@ -1,0 +1,129 @@
+import { CommonTokenStream } from 'antlr4ts';
+import { ErrorHandler, FlinkSQL } from '../../src';
+import { FlinkSqlLexer } from '../../src/lib/flinksql/FlinkSqlLexer';
+
+describe('BasicParser unit tests', () => {
+    const flinkParser = new FlinkSQL();
+    test('Create lexer', () => {
+        const sql = 'SELECT * FROM tb1';
+        const lexer = flinkParser.createLexer(sql);
+
+        expect(lexer).not.toBeUndefined();
+        expect(lexer).not.toBeNull();
+    });
+
+    test('Create lexer with errorHandler', () => {
+        const sql = '袋鼠云数栈UED团队';
+        const errors: any[] = [];
+        const errorHandler: ErrorHandler<any> = (err) => {
+            errors.push(err)
+        };
+        const lexer = flinkParser.createLexer(sql, errorHandler);
+        const tokenStream = new CommonTokenStream(lexer);
+        tokenStream.fill();
+        expect(errors.length).not.toBe(0);
+    });
+
+    test('Create parser', () => {
+        const sql = 'SELECT * FROM tb1';
+        const parser = flinkParser.createParser(sql);
+
+        expect(parser).not.toBeUndefined();
+        expect(parser).not.toBeNull();
+    });
+
+    test('Create parser with errorHandler (lexer error)', () => {
+        const sql = '袋鼠云数栈UED团队';
+        const errors: any[] = [];
+        const errorHandler: ErrorHandler<any> = (err) => {
+            errors.push(err);
+        };
+        const parser = flinkParser.createParser(sql, errorHandler);
+        parser.program();
+        expect(errors.length).not.toBe(0);
+    });
+
+    test('Create parser with errorHandler (parse error)', () => {
+        const sql = 'SHOW TA';
+        const errors: any[] = [];
+        const errorHandler: ErrorHandler<any> = (err) => {
+            errors.push(err);
+        };
+        const parser = flinkParser.createParser(sql, errorHandler);
+        parser.program();
+        expect(errors.length).not.toBe(0);
+    });
+
+    test('Parse right input', () => {
+        const sql = 'SELECT * FROM tb1';
+        const errors: any[] = [];
+        const errorHandler: ErrorHandler<any> = (err) => {
+            errors.push(err);
+        };
+        const parseTree = flinkParser.parse(sql, errorHandler);
+
+        expect(parseTree).not.toBeUndefined();
+        expect(parseTree).not.toBeNull();
+        expect(errors.length).toBe(0);
+    });
+
+    test('Parse wrong input', () => {
+        const sql = '袋鼠云数栈UED团队';
+        const errors: any[] = [];
+        const errorHandler: ErrorHandler<any> = (err) => {
+            errors.push(err);
+        };
+        const parseTree = flinkParser.parse(sql, errorHandler);
+
+        expect(parseTree).not.toBeUndefined();
+        expect(parseTree).not.toBeNull();
+        expect(errors.length).not.toBe(0);
+    });
+
+    test('Get All tokens', () => {
+        const sql = 'SELECT * FROM tbl1;';
+        const tokens = flinkParser.getAllTokens(sql);
+
+        expect(tokens.length).toBe(8);
+        expect(tokens[0].type).toBe(FlinkSqlLexer.KW_SELECT);
+        expect(tokens[1].type).toBe(FlinkSqlLexer.SPACE);
+        expect(tokens[2].type).toBe(FlinkSqlLexer.ASTERISK_SIGN);
+        expect(tokens[3].type).toBe(FlinkSqlLexer.SPACE);
+        expect(tokens[4].type).toBe(FlinkSqlLexer.KW_FROM);
+        expect(tokens[5].type).toBe(FlinkSqlLexer.SPACE);
+        expect(tokens[6].type).toBe(FlinkSqlLexer.ID_LITERAL);
+        expect(tokens[7].type).toBe(FlinkSqlLexer.SEMICOLON);
+    });
+
+    test('Get All tokens with error', () => {
+        const sql = '袋鼠云数栈UED团队';
+        const tokens = flinkParser.getAllTokens(sql);
+        expect(tokens.length).toBe(1);
+        expect(tokens[0].type).toBe(FlinkSqlLexer.ID_LITERAL);
+    });
+
+    test('Split sql', () => {
+        const sql = 'SHOW TABLES;\nSELECT * FROM tb;'
+        const sqlSlices = flinkParser.splitSQLByStatement(sql);
+
+        expect(sqlSlices.length).toBe(2);
+
+        expect(sqlSlices[0].text).toBe('SHOW TABLES;');
+        expect(sql.slice(sqlSlices[0].startIndex, sqlSlices[0].endIndex+1)).toBe(sqlSlices[0].text);
+        expect(sqlSlices[0].startLine).toBe(1);
+        expect(sqlSlices[0].endLine).toBe(1);
+
+        expect(sqlSlices[1].text).toBe('SELECT * FROM tb;');
+        expect(sql.slice(sqlSlices[1].startIndex, sqlSlices[1].endIndex+1)).toBe(sqlSlices[1].text);
+        expect(sqlSlices[1].startLine).toBe(2);
+        expect(sqlSlices[1].endLine).toBe(2);
+    });
+
+    test('Split sql with errors', () => {
+        const sql = 'SHOW TABLES;\nSELECT * FOM tb;'
+        const sqlSlices = flinkParser.splitSQLByStatement(sql);
+
+        expect(sqlSlices).toBeNull();
+    });
+
+});

--- a/test/common/basicParser.test.ts
+++ b/test/common/basicParser.test.ts
@@ -16,7 +16,7 @@ describe('BasicParser unit tests', () => {
         const sql = '袋鼠云数栈UED团队';
         const errors: any[] = [];
         const errorHandler: ErrorHandler<any> = (err) => {
-            errors.push(err)
+            errors.push(err);
         };
         const lexer = flinkParser.createLexer(sql, errorHandler);
         const tokenStream = new CommonTokenStream(lexer);
@@ -103,27 +103,30 @@ describe('BasicParser unit tests', () => {
     });
 
     test('Split sql', () => {
-        const sql = 'SHOW TABLES;\nSELECT * FROM tb;'
+        const sql = 'SHOW TABLES;\nSELECT * FROM tb;';
         const sqlSlices = flinkParser.splitSQLByStatement(sql);
 
         expect(sqlSlices.length).toBe(2);
 
         expect(sqlSlices[0].text).toBe('SHOW TABLES;');
-        expect(sql.slice(sqlSlices[0].startIndex, sqlSlices[0].endIndex+1)).toBe(sqlSlices[0].text);
+        expect(sql.slice(sqlSlices[0].startIndex, sqlSlices[0].endIndex + 1)).toBe(
+            sqlSlices[0].text
+        );
         expect(sqlSlices[0].startLine).toBe(1);
         expect(sqlSlices[0].endLine).toBe(1);
 
         expect(sqlSlices[1].text).toBe('SELECT * FROM tb;');
-        expect(sql.slice(sqlSlices[1].startIndex, sqlSlices[1].endIndex+1)).toBe(sqlSlices[1].text);
+        expect(sql.slice(sqlSlices[1].startIndex, sqlSlices[1].endIndex + 1)).toBe(
+            sqlSlices[1].text
+        );
         expect(sqlSlices[1].startLine).toBe(2);
         expect(sqlSlices[1].endLine).toBe(2);
     });
 
     test('Split sql with errors', () => {
-        const sql = 'SHOW TABLES;\nSELECT * FOM tb;'
+        const sql = 'SHOW TABLES;\nSELECT * FOM tb;';
         const sqlSlices = flinkParser.splitSQLByStatement(sql);
 
         expect(sqlSlices).toBeNull();
     });
-
 });

--- a/test/parser/flinksql/listener.test.ts
+++ b/test/parser/flinksql/listener.test.ts
@@ -8,7 +8,7 @@ describe('Flink SQL Listener Tests', () => {
     const sql = `select id,name,sex from ${expectTableName};`;
     const parser = new FlinkSQL();
 
-    const parserTree = parser.parse(sql);
+    const parseTree = parser.parse(sql);
 
     test('Listener enterTableName', async () => {
         let result = '';
@@ -19,7 +19,7 @@ describe('Flink SQL Listener Tests', () => {
         }
         const listenTableName = new MyListener();
 
-        await parser.listen(listenTableName as ParseTreeListener, parserTree);
+        await parser.listen(listenTableName as ParseTreeListener, parseTree);
         expect(result).toBe(expectTableName);
     });
 });

--- a/test/parser/flinksql/visitor.test.ts
+++ b/test/parser/flinksql/visitor.test.ts
@@ -7,7 +7,7 @@ describe('Flink SQL Visitor Tests', () => {
     const sql = `select id,name,sex from ${expectTableName};`;
     const parser = new FlinkSQL();
 
-    const parserTree = parser.parse(sql, (error) => {
+    const parseTree = parser.parse(sql, (error) => {
         console.log('Parse error:', error);
     });
 
@@ -25,7 +25,7 @@ describe('Flink SQL Visitor Tests', () => {
             };
         }
         const visitor: any = new MyVisitor();
-        visitor.visit(parserTree);
+        visitor.visit(parseTree);
 
         expect(result).toBe(expectTableName);
     });

--- a/test/parser/generic/listener.test.ts
+++ b/test/parser/generic/listener.test.ts
@@ -7,7 +7,7 @@ describe('Generic SQL Listener Tests', () => {
     const sql = `select id,name,sex from ${expectTableName};`;
     const parser = new GenericSQL();
 
-    const parserTree = parser.parse(sql);
+    const parseTree = parser.parse(sql);
 
     test('Listener enterTableName', async () => {
         let result = '';
@@ -18,7 +18,7 @@ describe('Generic SQL Listener Tests', () => {
         }
         const listenTableName: any = new MyListener();
 
-        await parser.listen(listenTableName as ParseTreeListener, parserTree);
+        await parser.listen(listenTableName as ParseTreeListener, parseTree);
         expect(result).toBe(expectTableName);
     });
 });

--- a/test/parser/generic/visitor.test.ts
+++ b/test/parser/generic/visitor.test.ts
@@ -7,7 +7,7 @@ describe('Generic SQL Visitor Tests', () => {
     const sql = `select id,name,sex from ${expectTableName};`;
     const parser = new GenericSQL();
 
-    const parserTree = parser.parse(sql, (error) => {
+    const parseTree = parser.parse(sql, (error) => {
         console.log('Parse error:', error);
     });
 
@@ -23,7 +23,7 @@ describe('Generic SQL Visitor Tests', () => {
             };
         }
         const visitor = new MyVisitor();
-        visitor.visit(parserTree);
+        visitor.visit(parseTree);
 
         expect(result).toBe(expectTableName);
     });

--- a/test/parser/hive/listener.test.ts
+++ b/test/parser/hive/listener.test.ts
@@ -8,7 +8,7 @@ describe('HiveSQL Listener Tests', () => {
     test('Listener enterSelectList', async () => {
         const expectTableName = 'username';
         const sql = `select ${expectTableName} from tablename where inc_day='20190601' limit 1000;`;
-        const parserTree = parser.parse(sql);
+        const parseTree = parser.parse(sql);
 
         let result = '';
         class MyListener implements HiveSqlParserListener {
@@ -18,12 +18,12 @@ describe('HiveSQL Listener Tests', () => {
         }
         const listenTableName = new MyListener();
 
-        await parser.listen(listenTableName as ParseTreeListener, parserTree as ProgramContext);
+        await parser.listen(listenTableName as ParseTreeListener, parseTree as ProgramContext);
         expect(result).toBe(expectTableName.toUpperCase());
     });
     test('Listener enterCreateTable', async () => {
         const sql = `drop table table_name;`;
-        const parserTree = parser.parse(sql);
+        const parseTree = parser.parse(sql);
         let result = '';
         class MyListener implements HiveSqlParserListener {
             enterDropTableStatement(ctx) {
@@ -32,7 +32,7 @@ describe('HiveSQL Listener Tests', () => {
         }
         const listenTableName = new MyListener();
 
-        await parser.listen(listenTableName as ParseTreeListener, parserTree as ProgramContext);
+        await parser.listen(listenTableName as ParseTreeListener, parseTree as ProgramContext);
         expect(result).toBe('DROPTABLETABLE_NAME');
     });
 });

--- a/test/parser/hive/visitor.test.ts
+++ b/test/parser/hive/visitor.test.ts
@@ -8,7 +8,7 @@ describe('HiveSQL Visitor Tests', () => {
     const sql = `select citycode,tc,inc_day from ${expectTableName} where inc_day='20190501' limit 100;`;
     const parser = new HiveSQL();
 
-    const parserTree = parser.parse(sql, (error) => {
+    const parseTree = parser.parse(sql, (error) => {
         console.log('Parse error:', error);
     });
 
@@ -25,7 +25,7 @@ describe('HiveSQL Visitor Tests', () => {
         }
 
         const visitor = new MyVisitor();
-        visitor.visit(parserTree as ProgramContext);
+        visitor.visit(parseTree as ProgramContext);
 
         expect(result).toBe(expectTableName);
     });

--- a/test/parser/pgsql/listener.test.ts
+++ b/test/parser/pgsql/listener.test.ts
@@ -8,7 +8,7 @@ describe('PostgresSQL Listener Tests', () => {
     const sql = `select id,name,sex from ${expectTableName};`;
     const parser = new PostgresSQL();
 
-    const parserTree = parser.parse(sql);
+    const parseTree = parser.parse(sql);
 
     test('Listener enterTableName', async () => {
         let result = '';
@@ -19,7 +19,7 @@ describe('PostgresSQL Listener Tests', () => {
         }
         const listenTableName = new MyListener();
 
-        await parser.listen(listenTableName as ParseTreeListener, parserTree);
+        await parser.listen(listenTableName as ParseTreeListener, parseTree);
         expect(result).toBe(expectTableName);
     });
 });

--- a/test/parser/pgsql/visitor.test.ts
+++ b/test/parser/pgsql/visitor.test.ts
@@ -7,7 +7,7 @@ describe('Generic SQL Visitor Tests', () => {
     const sql = `select id,name,sex from ${expectTableName};`;
     const parser = new PostgresSQL();
 
-    const parserTree = parser.parse(sql, (error) => {
+    const parseTree = parser.parse(sql, (error) => {
         console.log('Parse error:', error);
     });
 
@@ -26,7 +26,7 @@ describe('Generic SQL Visitor Tests', () => {
             }
         }
         const visitor: any = new MyVisitor();
-        visitor.visit(parserTree);
+        visitor.visit(parseTree);
 
         expect(result).toBe(expectTableName);
     });

--- a/test/parser/plsql/listener.test.ts
+++ b/test/parser/plsql/listener.test.ts
@@ -7,7 +7,7 @@ describe('PLSQL Listener Tests', () => {
     const sql = `select id,name,sex from ${expectTableName};`;
     const parser = new PLSQL();
 
-    const parserTree = parser.parse(sql);
+    const parseTree = parser.parse(sql);
 
     test('Listener enterTableName', async () => {
         let result = '';
@@ -18,7 +18,7 @@ describe('PLSQL Listener Tests', () => {
         }
         const listenTableName = new MyListener();
 
-        await parser.listen(listenTableName as ParseTreeListener, parserTree);
+        await parser.listen(listenTableName as ParseTreeListener, parseTree);
         expect(result).toBe(expectTableName);
     });
 });

--- a/test/parser/plsql/visitor.test.ts
+++ b/test/parser/plsql/visitor.test.ts
@@ -7,7 +7,7 @@ describe('PLSQL Visitor Tests', () => {
     const sql = `select id,name,sex from ${expectTableName};`;
     const parser = new PLSQL();
 
-    const parserTree = parser.parse(sql);
+    const parseTree = parser.parse(sql);
 
     test('Visitor visitTable_ref_list', () => {
         let result = '';
@@ -20,7 +20,7 @@ describe('PLSQL Visitor Tests', () => {
             };
         }
         const visitor: any = new MyVisitor();
-        visitor.visit(parserTree);
+        visitor.visit(parseTree);
 
         expect(result).toBe(expectTableName);
     });

--- a/test/parser/spark/listener.test.ts
+++ b/test/parser/spark/listener.test.ts
@@ -7,7 +7,7 @@ describe('Spark SQL Listener Tests', () => {
     const sql = `select id,name,sex from ${expectTableName};`;
     const parser = new SparkSQL();
 
-    const parserTree = parser.parse(sql);
+    const parseTree = parser.parse(sql);
 
     test('Listener exitRelationPrimary', () => {
         let result = '';
@@ -18,7 +18,7 @@ describe('Spark SQL Listener Tests', () => {
         }
         const listenTableName = new MyListener();
 
-        parser.listen(listenTableName as ParseTreeListener, parserTree);
+        parser.listen(listenTableName as ParseTreeListener, parseTree);
         expect(result).toBe(expectTableName);
     });
 });

--- a/test/parser/spark/visitor.test.ts
+++ b/test/parser/spark/visitor.test.ts
@@ -7,7 +7,7 @@ describe('Spark SQL Visitor Tests', () => {
     const sql = `select id,name,sex from ${expectTableName};`;
     const parser = new SparkSQL();
 
-    const parserTree = parser.parse(sql, (error) => {
+    const parseTree = parser.parse(sql, (error) => {
         console.log('Parse error:', error);
     });
 
@@ -25,7 +25,7 @@ describe('Spark SQL Visitor Tests', () => {
             };
         }
         const visitor = new MyVisitor();
-        visitor.visit(parserTree);
+        visitor.visit(parseTree);
 
         expect(visitor.result).toBe(expectTableName);
     });

--- a/test/parser/trinosql/listener.test.ts
+++ b/test/parser/trinosql/listener.test.ts
@@ -7,7 +7,7 @@ describe('trino SQL Listener Tests', () => {
     const sql = `select id,name,sex from ${expectTableName};`;
     const parser = new trinoSQL();
 
-    const parserTree = parser.parse(sql);
+    const parseTree = parser.parse(sql);
 
     test('Listener enterTableName', async () => {
         let result = '';
@@ -18,7 +18,7 @@ describe('trino SQL Listener Tests', () => {
         }
         const listenTableName = new MyListener();
 
-        await parser.listen(listenTableName as ParseTreeListener, parserTree);
+        await parser.listen(listenTableName as ParseTreeListener, parseTree);
         expect(result).toBe(expectTableName);
     });
 });

--- a/test/parser/trinosql/visitor.test.ts
+++ b/test/parser/trinosql/visitor.test.ts
@@ -7,7 +7,7 @@ describe('trino SQL Visitor Tests', () => {
     const sql = `select id,name,sex from ${expectTableName};`;
     const parser = new trinoSQL();
 
-    const parserTree = parser.parse(sql, (error) => {
+    const parseTree = parser.parse(sql, (error) => {
         console.log('Parse error:', error);
     });
 
@@ -22,7 +22,7 @@ describe('trino SQL Visitor Tests', () => {
             };
         }
         const visitor: any = new MyVisitor();
-        visitor.visit(parserTree);
+        visitor.visit(parseTree);
 
         expect(result).toBe(expectTableName);
     });


### PR DESCRIPTION
## 简介
重构BasicParser #137 

## 主要变更
1. 移除 `ErrorCollector`， 因为它与 `ErrorListener` 功能重复
2. 将 `basicParser` 中的 ErrorCollector 替换为 `ErrorListener` + `ErrorHandler`
3. 新增监听 lexer error 的逻辑
4. `splitSQLByStatement` 方法在遇到解析错误时，直接返回 `null`
5. 原有的 `parse` 方法更名为 `parseWithCache` 方法，此方法仅用于内部
6. 添加新的 `parse` 方法， 此方法不具有缓存上一次结果的功能
7. `parserTree` 重命名为 `parseTree`,`parserError` 重命名为 `parseError` 这更符合语义
8. 导出 `ErrorHandler` 类型
9. 添加 `basicParser` 相关单元测试

