### PR TITLE
Refactor/dir

### DIFF
--- a/src/parser/common/basic-parser-types.ts
+++ b/src/parser/common/basic-parser-types.ts
@@ -4,9 +4,9 @@
  */
 export interface CaretPosition {
     /** start at 1 */
-    lineNumber: number;
+    readonly lineNumber: number;
     /** start at 1 */
-    column: number;
+    readonly column: number;
 }
 
 /**
@@ -45,23 +45,23 @@ export enum SyntaxContextType {
 
 export interface WordRange {
     /** content of word */
-    text: string;
+    readonly text: string;
     /** start at 0 */
-    startIndex: number;
-    stopIndex: number;
+    readonly startIndex: number;
+    readonly stopIndex: number;
     /** start at 1 */
-    line: number;
+    readonly line: number;
     /** start at 1 */
-    startColumn: number;
-    stopColumn: number;
+    readonly startColumn: number;
+    readonly stopColumn: number;
 }
 
 /**
  * Suggested information analyzed from the input
  */
 export interface SyntaxSuggestion<T = WordRange> {
-    syntaxContextType: SyntaxContextType;
-    wordRanges: T[];
+    readonly syntaxContextType: SyntaxContextType;
+    readonly wordRanges: T[];
 }
 
 /**
@@ -71,22 +71,22 @@ export interface Suggestions<T = WordRange> {
     /**
      * Suggestions about syntax
      */
-    syntax: SyntaxSuggestion<T>[];
+    readonly syntax: SyntaxSuggestion<T>[];
     /**
      * Suggestions about keywords
      */
-    keywords: string[];
+    readonly keywords: string[];
 }
 
 export interface TextSlice {
     /** start at 0 */
-    startIndex: number;
-    endIndex: number;
+    readonly startIndex: number;
+    readonly endIndex: number;
     /** start at 1 */
-    startLine: number;
-    endLine: number;
+    readonly startLine: number;
+    readonly endLine: number;
     /** start at 1 */
-    startColumn: number;
-    endColumn: number;
-    text: string;
+    readonly startColumn: number;
+    readonly endColumn: number;
+    readonly text: string;
 }

--- a/src/parser/common/basicParser.ts
+++ b/src/parser/common/basicParser.ts
@@ -9,7 +9,7 @@ import {
 } from 'antlr4ts';
 import { ParseTreeWalker, ParseTreeListener } from 'antlr4ts/tree';
 import { CandidatesCollection, CodeCompletionCore } from 'antlr4-c3';
-import { findCaretTokenIndex } from '../../utils/findCaretTokenIndex';
+import { findCaretTokenIndex } from './utils/findCaretTokenIndex';
 import {
     CaretPosition,
     Suggestions,

--- a/src/parser/common/parseErrorListener.ts
+++ b/src/parser/common/parseErrorListener.ts
@@ -5,23 +5,23 @@ import { ATNSimulator } from 'antlr4ts/atn/ATNSimulator';
  * Converted from {@link SyntaxError}.
  */
 export interface ParseError {
-    startLine: number;
-    endLine: number;
-    startCol: number;
-    endCol: number;
-    message: string;
+    readonly startLine: number;
+    readonly endLine: number;
+    readonly startCol: number;
+    readonly endCol: number;
+    readonly message: string;
 }
 
 /**
  * The type of error resulting from lexical parsing and parsing.
  */
 export interface SyntaxError<T> {
-    recognizer: Recognizer<T, ATNSimulator>;
-    offendingSymbol: Token;
-    line: number;
-    charPositionInLine: number;
-    msg: string;
-    e: RecognitionException;
+    readonly recognizer: Recognizer<T, ATNSimulator>;
+    readonly offendingSymbol: Token;
+    readonly line: number;
+    readonly charPositionInLine: number;
+    readonly msg: string;
+    readonly e: RecognitionException;
 }
 
 /**

--- a/src/parser/common/utils/findCaretTokenIndex.ts
+++ b/src/parser/common/utils/findCaretTokenIndex.ts
@@ -1,5 +1,5 @@
 import { Token } from 'antlr4ts';
-import { CaretPosition } from '../parser/common/basic-parser-types';
+import { CaretPosition } from '../basic-parser-types';
 
 /**
  * find token index via caret position (cursor position)

--- a/src/parser/mysql.ts
+++ b/src/parser/mysql.ts
@@ -4,7 +4,7 @@ import { MySqlLexer } from '../lib/mysql/MySqlLexer';
 import { MySqlParser, ProgramContext, SingleStatementContext } from '../lib/mysql/MySqlParser';
 import BasicParser from './common/basicParser';
 import { Suggestions, SyntaxContextType, SyntaxSuggestion } from './common/basic-parser-types';
-import { MySqlParserListener } from 'src/lib/mysql/MySqlParserListener';
+import { MySqlParserListener } from '../lib/mysql/MySqlParserListener';
 
 export default class MySQL extends BasicParser<MySqlLexer, ProgramContext, MySqlParser> {
     protected createLexerFormCharStream(charStreams): MySqlLexer {

--- a/src/parser/spark.ts
+++ b/src/parser/spark.ts
@@ -8,7 +8,7 @@ import {
 } from '../lib/spark/SparkSqlParser';
 import BasicParser from './common/basicParser';
 import { Suggestions, SyntaxContextType, SyntaxSuggestion } from './common/basic-parser-types';
-import { SparkSqlParserListener } from 'src/lib/spark/SparkSqlParserListener';
+import { SparkSqlParserListener } from '../lib/spark/SparkSqlParserListener';
 
 export default class SparkSQL extends BasicParser<SparkSqlLexer, ProgramContext, SparkSqlParser> {
     protected createLexerFormCharStream(charStreams) {


### PR DESCRIPTION
## 主要变更
1. 修正导入路径，导入路径应该都是用相对路径，绝对路径在打包后运行时会报错
2. findCaretTokenIndex 文件移动到 parser/common/utils/ 目录下，未来会移除src/utils 文件夹及其下面所有的文件
3. 为项目内的接口中的成员添加 readonly 修饰符

