### PR TITLE
Fix/export abstract visitor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,45 @@
-export * from './parser';
-export * from './lib/flinksql/FlinkSqlParserListener';
-export * from './lib/flinksql/FlinkSqlParserVisitor';
-export * from './lib/mysql/MySqlParserVisitor';
-export * from './lib/mysql/MySqlParserListener';
-export * from './lib/hive/HiveSqlParserListener';
-export * from './lib/hive/HiveSqlParserVisitor';
-export * from './lib/plsql/PlSqlParserListener';
-export * from './lib/plsql/PlSqlParserVisitor';
-export * from './lib/spark/SparkSqlParserVisitor';
-export * from './lib/spark/SparkSqlParserListener';
-export * from './lib/pgsql/PostgreSQLParserListener';
-export * from './lib/pgsql/PostgreSQLParserVisitor';
-export * from './lib/trinosql/TrinoSqlListener';
-export * from './lib/trinosql/TrinoSqlVisitor';
-export * from './lib/impala/ImpalaSqlParserListener';
-export * from './lib/impala/ImpalaSqlParserVisitor';
+export { AbstractParseTreeVisitor } from 'antlr4ts/tree/AbstractParseTreeVisitor';
+
+export {
+    MySQL,
+    FlinkSQL,
+    SparkSQL,
+    HiveSQL,
+    PostgresSQL,
+    TrinoSQL,
+    ImpalaSQL,
+    PLSQL,
+} from './parser';
+
+export {
+    MySqlParserListener,
+    MySqlParserVisitor,
+    FlinkSqlParserListener,
+    FlinkSqlParserVisitor,
+    SparkSqlParserListener,
+    SparkSqlParserVisitor,
+    HiveSqlParserListener,
+    HiveSqlParserVisitor,
+    PlSqlParserListener,
+    PlSqlParserVisitor,
+    PostgreSQLParserListener,
+    PostgreSQLParserVisitor,
+    TrinoSqlListener,
+    TrinoSqlVisitor,
+    ImpalaSqlParserListener,
+    ImpalaSqlParserVisitor,
+} from './lib';
+
 export { SyntaxContextType } from './parser/common/basic-parser-types';
 
-export type * from './parser/common/basic-parser-types';
+export type {
+    CaretPosition,
+    WordRange,
+    Suggestions,
+    SyntaxSuggestion,
+    TextSlice,
+} from './parser/common/basic-parser-types';
+
 export type { SyntaxError, ParseError, ErrorListener } from './parser/common/parseErrorListener';
 
 /**

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,23 @@
+export { FlinkSqlParserListener } from './flinksql/FlinkSqlParserListener';
+export { FlinkSqlParserVisitor } from './flinksql/FlinkSqlParserVisitor';
+
+export { MySqlParserListener } from './mysql/MySqlParserListener';
+export { MySqlParserVisitor } from './mysql/MySqlParserVisitor';
+
+export { HiveSqlParserListener } from './hive/HiveSqlParserListener';
+export { HiveSqlParserVisitor } from './hive/HiveSqlParserVisitor';
+
+export { PlSqlParserListener } from './plsql/PlSqlParserListener';
+export { PlSqlParserVisitor } from './plsql/PlSqlParserVisitor';
+
+export { SparkSqlParserListener } from './spark/SparkSqlParserListener';
+export { SparkSqlParserVisitor } from './spark/SparkSqlParserVisitor';
+
+export { PostgreSQLParserListener } from './pgsql/PostgreSQLParserListener';
+export { PostgreSQLParserVisitor } from './pgsql/PostgreSQLParserVisitor';
+
+export { TrinoSqlListener } from './trinosql/TrinoSqlListener';
+export { TrinoSqlVisitor } from './trinosql/TrinoSqlVisitor';
+
+export { ImpalaSqlParserListener } from './impala/ImpalaSqlParserListener';
+export { ImpalaSqlParserVisitor } from './impala/ImpalaSqlParserVisitor';

--- a/test/common/basicParser.test.ts
+++ b/test/common/basicParser.test.ts
@@ -1,6 +1,4 @@
-import { CommonTokenStream } from 'antlr4ts';
-import { ErrorListener, FlinkSQL } from '../../src';
-import { FlinkSqlLexer } from '../../src/lib/flinksql/FlinkSqlLexer';
+import { CommonTokenStream, ErrorListener, FlinkSQL, FlinkSqlLexer } from '../filters';
 
 describe('BasicParser unit tests', () => {
     const flinkParser = new FlinkSQL();

--- a/test/filters/index.ts
+++ b/test/filters/index.ts
@@ -1,0 +1,63 @@
+/**
+ * All unit tests should import parser about from this file.
+ * In this way, the exports of dt-sql-parser in the entry file is guaranteed to be complete.
+ *
+ * 单测文件中有关 parser 的导入，都应该从这个文件中导入。
+ * 通过这种方式，能保证 dt-sql-parser 的入口文件中的导出完整。
+ *
+ * See this issue https://github.com/DTStack/dt-sql-parser/issues/236.
+ */
+
+export * from '../../src';
+
+/**
+ * Something required by unit test but dt-sql-parser'entry not.
+ * If you need to add an export to this file,
+ * consider whether it should be exported in src/index as well.
+ *
+ * 一些单测文件需要但是 dt-sql-parser的入口不需要的导出。
+ * 如果你需要在这个文件中添加新的导出，请考虑它是否应该在 dt-sql-parser 的入口文件中导出。
+ */
+export { CommonTokenStream } from 'antlr4ts';
+
+export { ParseTreeWalker, ParseTreeListener } from 'antlr4ts/tree';
+
+export { FlinkSqlLexer } from '../../src/lib/flinksql/FlinkSqlLexer';
+export { FlinkSqlParser } from '../../src/lib/flinksql/FlinkSqlParser';
+export * as FlinkSqlParserRuleContext from '../../src/lib/flinksql/FlinkSqlParser';
+
+export { MySqlLexer } from '../../src/lib/mysql/MySqlLexer';
+export { MySqlParser } from '../../src/lib/mysql/MySqlParser';
+export * as MySqlParserRuleContext from '../../src/lib/mysql/MySqlParser';
+
+export { HiveSqlLexer } from '../../src/lib/hive/HiveSqlLexer';
+export { HiveSqlParser } from '../../src/lib/hive/HiveSqlParser';
+export * as HiveSqlParserRuleContext from '../../src/lib/hive/HiveSqlParser';
+
+export { PlSqlLexer } from '../../src/lib/plsql/PlSqlLexer';
+export { PlSqlParser } from '../../src/lib/plsql/PlSqlParser';
+export * as PlSqlParserRuleContext from '../../src/lib/plsql/PlSqlParser';
+
+export { SparkSqlLexer } from '../../src/lib/spark/SparkSqlLexer';
+export { SparkSqlParser } from '../../src/lib/spark/SparkSqlParser';
+export * as SparkSQLParserRuleContext from '../../src/lib/spark/SparkSqlParser';
+
+export { PostgreSQLLexer } from '../../src/lib/pgsql/PostgreSQLLexer';
+export { PostgreSQLParser } from '../../src/lib/pgsql/PostgreSQLParser';
+export * as PostgreSQLParserRuleContext from '../../src/lib/pgsql/PostgreSQLParser';
+
+export { TrinoSqlLexer } from '../../src/lib/trinosql/TrinoSqlLexer';
+export { TrinoSqlParser } from '../../src/lib/trinosql/TrinoSqlParser';
+export * as TrinoSqlParserRuleContext from '../../src/lib/trinosql/TrinoSqlParser';
+
+export { ImpalaSqlLexer } from '../../src/lib/impala/ImpalaSqlLexer';
+export { ImpalaSqlParser } from '../../src/lib/impala/ImpalaSqlParser';
+export * as ImpalaSqlParserRuleContext from '../../src/lib/impala/ImpalaSqlParser';
+
+export { FlinkSqlSplitListener } from '../../src/parser/flinksql';
+export { MysqlSplitListener } from '../../src/parser/mysql';
+export { HiveSqlSplitListener } from '../../src/parser/hive';
+export { SparkSqlSplitListener } from '../../src/parser/spark';
+export { PgSqlSplitListener } from '../../src/parser/pgsql';
+export { TrinoSqlSplitListener } from '../../src/parser/trinosql';
+export { ImpalaSqlSplitListener } from '../../src/parser/impala';

--- a/test/parser/flinksql/benchmark/main.test.ts
+++ b/test/parser/flinksql/benchmark/main.test.ts
@@ -1,7 +1,4 @@
-import path from 'path';
-import { writeFileSync } from 'node:fs';
-
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL } from '../../../filters';
 import {
     readSQL,
     benchmark,

--- a/test/parser/flinksql/errorStrategy.test.ts
+++ b/test/parser/flinksql/errorStrategy.test.ts
@@ -1,6 +1,4 @@
-import FlinkSQL from '../../../src/parser/flinksql';
-import { FlinkSqlSplitListener } from '../../../src/parser/flinksql';
-import { FlinkSqlParserListener } from '../../../src/lib/flinksql/FlinkSqlParserListener';
+import { FlinkSQL, FlinkSqlSplitListener, FlinkSqlParserListener } from '../../filters';
 
 const validSQL1 = `INSERT INTO country_page_view
 VALUES ('Chinese', 'mumiao', 18),

--- a/test/parser/flinksql/lexer.test.ts
+++ b/test/parser/flinksql/lexer.test.ts
@@ -1,4 +1,4 @@
-import FlinkSQL from '../../../src/parser/flinksql';
+import { FlinkSQL } from '../../filters';
 
 describe('FlinkSQL Lexer tests', () => {
     const parser = new FlinkSQL();

--- a/test/parser/flinksql/listener.test.ts
+++ b/test/parser/flinksql/listener.test.ts
@@ -1,7 +1,9 @@
-import FlinkSQL from '../../../src/parser/flinksql';
-import { FlinkSqlParserListener } from '../../../src/lib/flinksql/FlinkSqlParserListener';
-import { TableExpressionContext } from '../../../src/lib/flinksql/FlinkSqlParser';
-import { ParseTreeListener } from 'antlr4ts/tree';
+import {
+    FlinkSQL,
+    FlinkSqlParserListener,
+    FlinkSqlParserRuleContext,
+    ParseTreeListener,
+} from '../../filters';
 
 describe('Flink SQL Listener Tests', () => {
     const expectTableName = 'user1';
@@ -13,7 +15,9 @@ describe('Flink SQL Listener Tests', () => {
     test('Listener enterTableName', async () => {
         let result = '';
         class MyListener implements FlinkSqlParserListener {
-            enterTableExpression = (ctx: TableExpressionContext): void => {
+            enterTableExpression = (
+                ctx: FlinkSqlParserRuleContext.TableExpressionContext
+            ): void => {
                 result = ctx.text.toLowerCase();
             };
         }

--- a/test/parser/flinksql/suggestion/multipleStatement.test.ts
+++ b/test/parser/flinksql/suggestion/multipleStatement.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition, SyntaxContextType } from '../../../../src/parser/common/basic-parser-types';
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { CaretPosition, SyntaxContextType, FlinkSQL } from '../../../filters';
 
 const syntaxSql = fs.readFileSync(
     path.join(__dirname, 'fixtures', 'multipleStatement.sql'),

--- a/test/parser/flinksql/suggestion/syntaxSuggestion.test.ts
+++ b/test/parser/flinksql/suggestion/syntaxSuggestion.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition, SyntaxContextType } from '../../../../src/parser/common/basic-parser-types';
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { CaretPosition, SyntaxContextType, FlinkSQL } from '../../../filters';
 import { commentOtherLine } from '../../../helper';
 
 const syntaxSql = fs.readFileSync(

--- a/test/parser/flinksql/suggestion/tokenSuggestion.test.ts
+++ b/test/parser/flinksql/suggestion/tokenSuggestion.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition } from '../../../../src/parser/common/basic-parser-types';
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL, CaretPosition } from '../../../filters';
 import { commentOtherLine } from '../../../helper';
 
 const tokenSql = fs.readFileSync(path.join(__dirname, 'fixtures', 'tokenSuggestion.sql'), 'utf-8');

--- a/test/parser/flinksql/syntax/alterStatement.test.ts
+++ b/test/parser/flinksql/syntax/alterStatement.test.ts
@@ -1,4 +1,4 @@
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/flinksql/syntax/choreStatement.test.ts
+++ b/test/parser/flinksql/syntax/choreStatement.test.ts
@@ -1,4 +1,4 @@
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 // 综合测试的 sql 不做切割

--- a/test/parser/flinksql/syntax/commentStatement.test.ts
+++ b/test/parser/flinksql/syntax/commentStatement.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL } from '../../../filters';
 
 // 注释 sql 不做切割
 const features = {

--- a/test/parser/flinksql/syntax/comprehensive.test.ts
+++ b/test/parser/flinksql/syntax/comprehensive.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL } from '../../../filters';
 
 // 综合测试的 sql 不做切割
 const features = {

--- a/test/parser/flinksql/syntax/createStatement.test.ts
+++ b/test/parser/flinksql/syntax/createStatement.test.ts
@@ -1,4 +1,4 @@
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new FlinkSQL();

--- a/test/parser/flinksql/syntax/describeStatement.test.ts
+++ b/test/parser/flinksql/syntax/describeStatement.test.ts
@@ -1,4 +1,4 @@
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/flinksql/syntax/dropStatement.test.ts
+++ b/test/parser/flinksql/syntax/dropStatement.test.ts
@@ -1,4 +1,4 @@
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/flinksql/syntax/dtAddFileStatement.test.ts
+++ b/test/parser/flinksql/syntax/dtAddFileStatement.test.ts
@@ -1,4 +1,4 @@
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/flinksql/syntax/explainStatement.test.ts
+++ b/test/parser/flinksql/syntax/explainStatement.test.ts
@@ -1,4 +1,4 @@
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/flinksql/syntax/expressionStatement.test.ts
+++ b/test/parser/flinksql/syntax/expressionStatement.test.ts
@@ -1,4 +1,4 @@
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/flinksql/syntax/insertStatement.test.ts
+++ b/test/parser/flinksql/syntax/insertStatement.test.ts
@@ -1,4 +1,4 @@
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new FlinkSQL();

--- a/test/parser/flinksql/syntax/selectStatement.test.ts
+++ b/test/parser/flinksql/syntax/selectStatement.test.ts
@@ -1,4 +1,4 @@
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new FlinkSQL();

--- a/test/parser/flinksql/syntax/showStatement.test.ts
+++ b/test/parser/flinksql/syntax/showStatement.test.ts
@@ -1,4 +1,4 @@
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/flinksql/syntax/useStatement.test.ts
+++ b/test/parser/flinksql/syntax/useStatement.test.ts
@@ -1,4 +1,4 @@
-import FlinkSQL from '../../../../src/parser/flinksql';
+import { FlinkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/flinksql/visitor.test.ts
+++ b/test/parser/flinksql/visitor.test.ts
@@ -1,6 +1,4 @@
-import FlinkSQL from '../../../src/parser/flinksql';
-import { FlinkSqlParserVisitor } from '../../../src/lib/flinksql/FlinkSqlParserVisitor';
-import { AbstractParseTreeVisitor } from 'antlr4ts/tree';
+import { FlinkSQL, AbstractParseTreeVisitor, FlinkSqlParserVisitor } from '../../filters';
 
 describe('Flink SQL Visitor Tests', () => {
     const expectTableName = 'user1';

--- a/test/parser/hive/errorStrategy.test.ts
+++ b/test/parser/hive/errorStrategy.test.ts
@@ -1,6 +1,4 @@
-import HiveSQL from '../../../src/parser/hive';
-import { HiveSqlSplitListener } from '../../../src/parser/hive';
-import { HiveSqlParserListener } from '../../../src/lib/hive/HiveSqlParserListener';
+import { HiveSQL, HiveSqlSplitListener, HiveSqlParserListener } from '../../filters';
 
 const validSQL1 = `INSERT INTO country_page_view
 VALUES ('Chinese', 'mumiao', 18),

--- a/test/parser/hive/lexer.test.ts
+++ b/test/parser/hive/lexer.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../src/parser/hive';
+import { HiveSQL } from '../../filters';
 
 describe('HiveSQL Lexer tests', () => {
     const parser = new HiveSQL();

--- a/test/parser/hive/listener.test.ts
+++ b/test/parser/hive/listener.test.ts
@@ -1,7 +1,5 @@
 import { ParseTreeListener } from 'antlr4ts/tree';
-import { ProgramContext } from '../../../src/lib/hive/HiveSqlParser';
-import { HiveSqlParserListener } from '../../../src/lib/hive/HiveSqlParserListener';
-import HiveSQL from '../../../src/parser/hive';
+import { HiveSQL, HiveSqlParserListener, HiveSqlParserRuleContext } from '../../filters';
 
 describe('HiveSQL Listener Tests', () => {
     const parser = new HiveSQL();
@@ -18,7 +16,10 @@ describe('HiveSQL Listener Tests', () => {
         }
         const listenTableName = new MyListener();
 
-        await parser.listen(listenTableName as ParseTreeListener, parseTree as ProgramContext);
+        await parser.listen(
+            listenTableName as ParseTreeListener,
+            parseTree as HiveSqlParserRuleContext.ProgramContext
+        );
         expect(result).toBe(expectTableName.toUpperCase());
     });
     test('Listener enterCreateTable', async () => {
@@ -32,7 +33,10 @@ describe('HiveSQL Listener Tests', () => {
         }
         const listenTableName = new MyListener();
 
-        await parser.listen(listenTableName as ParseTreeListener, parseTree as ProgramContext);
+        await parser.listen(
+            listenTableName as ParseTreeListener,
+            parseTree as HiveSqlParserRuleContext.ProgramContext
+        );
         expect(result).toBe('DROPTABLETABLE_NAME');
     });
 

--- a/test/parser/hive/suggestion/multipleStatement.test.ts
+++ b/test/parser/hive/suggestion/multipleStatement.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition, SyntaxContextType } from '../../../../src/parser/common/basic-parser-types';
-import HiveSQL from '../../../../src/parser/hive';
+import { CaretPosition, SyntaxContextType, HiveSQL } from '../../../filters';
 
 const syntaxSql = fs.readFileSync(
     path.join(__dirname, 'fixtures', 'multipleStatement.sql'),

--- a/test/parser/hive/suggestion/syntaxSuggestion.test.ts
+++ b/test/parser/hive/suggestion/syntaxSuggestion.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition, SyntaxContextType } from '../../../../src/parser/common/basic-parser-types';
-import HiveSQL from '../../../../src/parser/hive';
+import { CaretPosition, SyntaxContextType, HiveSQL } from '../../../filters';
 import { commentOtherLine } from '../../../helper';
 
 const syntaxSql = fs.readFileSync(

--- a/test/parser/hive/suggestion/tokenSuggestion.test.ts
+++ b/test/parser/hive/suggestion/tokenSuggestion.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition } from '../../../../src/parser/common/basic-parser-types';
-import HiveSQL from '../../../../src/parser/hive';
+import { CaretPosition, HiveSQL } from '../../../filters';
 import { commentOtherLine } from '../../../helper';
 
 const tokenSql = fs.readFileSync(path.join(__dirname, 'fixtures', 'tokenSuggestion.sql'), 'utf-8');

--- a/test/parser/hive/syntax/abortStatement.test.ts
+++ b/test/parser/hive/syntax/abortStatement.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new HiveSQL();

--- a/test/parser/hive/syntax/alterStatement.test.ts
+++ b/test/parser/hive/syntax/alterStatement.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new HiveSQL();

--- a/test/parser/hive/syntax/authorizationStatement.test.ts
+++ b/test/parser/hive/syntax/authorizationStatement.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new HiveSQL();

--- a/test/parser/hive/syntax/createStatement.test.ts
+++ b/test/parser/hive/syntax/createStatement.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new HiveSQL();

--- a/test/parser/hive/syntax/dataTypesStatement.test.ts
+++ b/test/parser/hive/syntax/dataTypesStatement.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new HiveSQL();

--- a/test/parser/hive/syntax/delete.test.ts
+++ b/test/parser/hive/syntax/delete.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new HiveSQL();

--- a/test/parser/hive/syntax/describeStatement.test.ts
+++ b/test/parser/hive/syntax/describeStatement.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new HiveSQL();

--- a/test/parser/hive/syntax/dropStatement.test.ts
+++ b/test/parser/hive/syntax/dropStatement.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new HiveSQL();

--- a/test/parser/hive/syntax/exportStatement.test.ts
+++ b/test/parser/hive/syntax/exportStatement.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/hive/syntax/importStatement.test.ts
+++ b/test/parser/hive/syntax/importStatement.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/hive/syntax/insertStatement.test.ts
+++ b/test/parser/hive/syntax/insertStatement.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new HiveSQL();

--- a/test/parser/hive/syntax/loadStatement.test.ts
+++ b/test/parser/hive/syntax/loadStatement.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new HiveSQL();

--- a/test/parser/hive/syntax/merge.test.ts
+++ b/test/parser/hive/syntax/merge.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new HiveSQL();

--- a/test/parser/hive/syntax/selectStatement.test.ts
+++ b/test/parser/hive/syntax/selectStatement.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new HiveSQL();

--- a/test/parser/hive/syntax/showStatement.test.ts
+++ b/test/parser/hive/syntax/showStatement.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new HiveSQL();

--- a/test/parser/hive/syntax/update.test.ts
+++ b/test/parser/hive/syntax/update.test.ts
@@ -1,4 +1,4 @@
-import HiveSQL from '../../../../src/parser/hive';
+import { HiveSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new HiveSQL();

--- a/test/parser/hive/visitor.test.ts
+++ b/test/parser/hive/visitor.test.ts
@@ -1,7 +1,9 @@
-import { AbstractParseTreeVisitor } from 'antlr4ts/tree/AbstractParseTreeVisitor';
-import { HiveSqlParserVisitor } from '../../../src/lib/hive/HiveSqlParserVisitor';
-import HiveSQL from '../../../src/parser/hive';
-import { ProgramContext } from '../../../src/lib/hive/HiveSqlParser';
+import {
+    HiveSQL,
+    HiveSqlParserVisitor,
+    AbstractParseTreeVisitor,
+    HiveSqlParserRuleContext,
+} from '../../filters';
 
 describe('HiveSQL Visitor Tests', () => {
     const expectTableName = 'dm_gis.dlv_addr_tc_count';
@@ -25,7 +27,7 @@ describe('HiveSQL Visitor Tests', () => {
         }
 
         const visitor = new MyVisitor();
-        visitor.visit(parseTree as ProgramContext);
+        visitor.visit(parseTree as HiveSqlParserRuleContext.ProgramContext);
 
         expect(result).toBe(expectTableName);
     });

--- a/test/parser/impala/errorStrategy.test.ts
+++ b/test/parser/impala/errorStrategy.test.ts
@@ -1,6 +1,4 @@
-import ImpalaSQL from '../../../src/parser/impala';
-import { ImpalaSqlSplitListener } from '../../../src/parser/impala';
-import { ImpalaSqlParserListener } from '../../../src/lib/impala/ImpalaSqlParserListener';
+import { ImpalaSQL, ImpalaSqlSplitListener, ImpalaSqlParserListener } from '../../filters';
 
 const validSQL1 = `INSERT INTO country_page_view
 VALUES ('Chinese', 'mumiao', 18),

--- a/test/parser/impala/lexer.test.ts
+++ b/test/parser/impala/lexer.test.ts
@@ -1,4 +1,4 @@
-import ImpalaSQL from '../../../src/parser/impala';
+import { ImpalaSQL } from '../../filters';
 
 describe('ImpalaSQL Lexer tests', () => {
     const parser = new ImpalaSQL();

--- a/test/parser/impala/listener.test.ts
+++ b/test/parser/impala/listener.test.ts
@@ -1,11 +1,9 @@
-import impalaSQL from '../../../src/parser/impala';
-import { ImpalaSqlParserListener } from '../../../src/lib/impala/ImpalaSqlParserListener';
-import { ParseTreeListener } from 'antlr4ts/tree';
+import { ImpalaSQL, ImpalaSqlParserListener, ParseTreeListener } from '../../filters';
 
 describe('impala SQL Listener Tests', () => {
     const expectTableName = 'user1';
     const sql = `select id,name,sex from ${expectTableName};`;
-    const parser = new impalaSQL();
+    const parser = new ImpalaSQL();
 
     const parseTree = parser.parse(sql);
 

--- a/test/parser/impala/suggestion/multipleStatement.test.ts
+++ b/test/parser/impala/suggestion/multipleStatement.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition, SyntaxContextType } from '../../../../src/parser/common/basic-parser-types';
-import ImpalaSQL from '../../../../src/parser/impala';
+import { ImpalaSQL, CaretPosition, SyntaxContextType } from '../../../filters';
 
 const syntaxSql = fs.readFileSync(
     path.join(__dirname, 'fixtures', 'multipleStatement.sql'),

--- a/test/parser/impala/suggestion/syntaxSuggestion.test.ts
+++ b/test/parser/impala/suggestion/syntaxSuggestion.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition, SyntaxContextType } from '../../../../src/parser/common/basic-parser-types';
-import ImpalaSQL from '../../../../src/parser/impala';
+import { ImpalaSQL, CaretPosition, SyntaxContextType } from '../../../filters';
 import { commentOtherLine } from '../../../helper';
 
 const syntaxSql = fs.readFileSync(

--- a/test/parser/impala/suggestion/tokenSuggestion.test.ts
+++ b/test/parser/impala/suggestion/tokenSuggestion.test.ts
@@ -1,13 +1,12 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition } from '../../../../src/parser/common/basic-parser-types';
-import impalaSQL from '../../../../src/parser/impala';
+import { ImpalaSQL, CaretPosition } from '../../../filters';
 import { commentOtherLine } from '../../../helper';
 
 const tokenSql = fs.readFileSync(path.join(__dirname, 'fixtures', 'tokenSuggestion.sql'), 'utf-8');
 
 describe('Impala SQL Token Suggestion', () => {
-    const parser = new impalaSQL();
+    const parser = new ImpalaSQL();
 
     test('After ALTER', () => {
         const pos: CaretPosition = {

--- a/test/parser/impala/syntax/alterStatement.test.ts
+++ b/test/parser/impala/syntax/alterStatement.test.ts
@@ -1,4 +1,4 @@
-import ImpalaSQL from '../../../../src/parser/impala';
+import { ImpalaSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new ImpalaSQL();

--- a/test/parser/impala/syntax/creataStatement.test.ts
+++ b/test/parser/impala/syntax/creataStatement.test.ts
@@ -1,4 +1,4 @@
-import ImpalaSQL from '../../../../src/parser/impala';
+import { ImpalaSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new ImpalaSQL();

--- a/test/parser/impala/syntax/delete.test.ts
+++ b/test/parser/impala/syntax/delete.test.ts
@@ -1,4 +1,4 @@
-import ImpalaSQL from '../../../../src/parser/impala';
+import { ImpalaSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new ImpalaSQL();

--- a/test/parser/impala/syntax/dropStatement.test.ts
+++ b/test/parser/impala/syntax/dropStatement.test.ts
@@ -1,4 +1,4 @@
-import ImpalaSQL from '../../../../src/parser/impala';
+import { ImpalaSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new ImpalaSQL();

--- a/test/parser/impala/syntax/insert.test.ts
+++ b/test/parser/impala/syntax/insert.test.ts
@@ -1,4 +1,4 @@
-import ImpalaSQL from '../../../../src/parser/impala';
+import { ImpalaSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new ImpalaSQL();

--- a/test/parser/impala/syntax/otherStatement.test.ts
+++ b/test/parser/impala/syntax/otherStatement.test.ts
@@ -1,4 +1,4 @@
-import ImpalaSQL from '../../../../src/parser/impala';
+import { ImpalaSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new ImpalaSQL();

--- a/test/parser/impala/syntax/refresh.test.ts
+++ b/test/parser/impala/syntax/refresh.test.ts
@@ -1,4 +1,4 @@
-import ImpalaSQL from '../../../../src/parser/impala';
+import { ImpalaSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new ImpalaSQL();

--- a/test/parser/impala/syntax/select.test.ts
+++ b/test/parser/impala/syntax/select.test.ts
@@ -1,4 +1,4 @@
-import ImpalaSQL from '../../../../src/parser/impala';
+import { ImpalaSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new ImpalaSQL();

--- a/test/parser/impala/syntax/show.test.ts
+++ b/test/parser/impala/syntax/show.test.ts
@@ -1,4 +1,4 @@
-import ImpalaSQL from '../../../../src/parser/impala';
+import { ImpalaSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new ImpalaSQL();

--- a/test/parser/impala/syntax/update.test.ts
+++ b/test/parser/impala/syntax/update.test.ts
@@ -1,4 +1,4 @@
-import ImpalaSQL from '../../../../src/parser/impala';
+import { ImpalaSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new ImpalaSQL();

--- a/test/parser/impala/syntax/upsert.test.ts
+++ b/test/parser/impala/syntax/upsert.test.ts
@@ -1,4 +1,4 @@
-import ImpalaSQL from '../../../../src/parser/impala';
+import { ImpalaSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new ImpalaSQL();

--- a/test/parser/impala/visitor.test.ts
+++ b/test/parser/impala/visitor.test.ts
@@ -1,11 +1,9 @@
-import impalaSQL from '../../../src/parser/impala';
-import { ImpalaSqlParserVisitor } from '../../../src/lib/impala/ImpalaSqlParserVisitor';
-import { AbstractParseTreeVisitor } from 'antlr4ts/tree';
+import { ImpalaSQL, ImpalaSqlParserVisitor, AbstractParseTreeVisitor } from '../../filters';
 
 describe('impala SQL Visitor Tests', () => {
     const expectTableName = 'user1';
     const sql = `select id,name,sex from ${expectTableName};`;
-    const parser = new impalaSQL();
+    const parser = new ImpalaSQL();
 
     const parseTree = parser.parse(sql, (error) => {
         console.log('Parse error:', error);

--- a/test/parser/mysql/errorStrategy.test.ts
+++ b/test/parser/mysql/errorStrategy.test.ts
@@ -1,6 +1,5 @@
-import MySQL from '../../../src/parser/mysql';
-import { MysqlSplitListener } from '../../../src/parser/mysql';
-import { MySqlParserListener } from '../../../src/lib/mysql/MySqlParserListener';
+import { MySQL } from '../../filters';
+import { MysqlSplitListener, MySqlParserListener } from '../../filters';
 
 const validSQL1 = `INSERT INTO country_page_view
 VALUES ('Chinese', 'mumiao', 18),

--- a/test/parser/mysql/lexer.test.ts
+++ b/test/parser/mysql/lexer.test.ts
@@ -1,4 +1,4 @@
-import MySQL from '../../../src/parser/mysql';
+import { MySQL } from '../../filters';
 
 describe('MySQL Lexer tests', () => {
     const parser = new MySQL();

--- a/test/parser/mysql/listener.test.ts
+++ b/test/parser/mysql/listener.test.ts
@@ -1,6 +1,5 @@
-import MySQL from '../../../src/parser/mysql';
-import { MySqlParserListener } from '../../../src/lib/mysql/MySqlParserListener';
-import { ParseTreeListener } from 'antlr4ts/tree';
+import { MySQL } from '../../filters';
+import { MySqlParserListener, ParseTreeListener } from '../../filters';
 
 describe('MySQL Listener Tests', () => {
     const expectTableName = 'user1';

--- a/test/parser/mysql/suggestion/multipleStatement.test.ts
+++ b/test/parser/mysql/suggestion/multipleStatement.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition, SyntaxContextType } from '../../../../src/parser/common/basic-parser-types';
-import MySQL from '../../../../src/parser/mysql';
+import { MySQL, CaretPosition, SyntaxContextType } from '../../../filters';
 
 const syntaxSql = fs.readFileSync(
     path.join(__dirname, 'fixtures', 'multipleStatement.sql'),

--- a/test/parser/mysql/suggestion/syntaxSuggestion.test.ts
+++ b/test/parser/mysql/suggestion/syntaxSuggestion.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition, SyntaxContextType } from '../../../../src/parser/common/basic-parser-types';
-import MySQL from '../../../../src/parser/mysql';
+import { MySQL, CaretPosition, SyntaxContextType } from '../../../filters';
 import { commentOtherLine } from '../../../helper';
 
 const syntaxSql = fs.readFileSync(

--- a/test/parser/mysql/suggestion/tokenSuggestion.test.ts
+++ b/test/parser/mysql/suggestion/tokenSuggestion.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition } from '../../../../src/parser/common/basic-parser-types';
-import MySQL from '../../../../src/parser/mysql';
+import { MySQL, CaretPosition } from '../../../filters';
 import { commentOtherLine } from '../../../helper';
 
 const tokenSql = fs.readFileSync(path.join(__dirname, 'fixtures', 'tokenSuggestion.sql'), 'utf-8');

--- a/test/parser/mysql/syntax.test.ts
+++ b/test/parser/mysql/syntax.test.ts
@@ -1,4 +1,4 @@
-import MySQL from '../../../src/parser/mysql';
+import { MySQL } from '../../filters';
 
 describe('MySQL Syntax Tests', () => {
     const parser = new MySQL();

--- a/test/parser/mysql/syntax/administration.test.ts
+++ b/test/parser/mysql/syntax/administration.test.ts
@@ -1,4 +1,4 @@
-import MySQL from '../../../../src/parser/mysql';
+import { MySQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new MySQL();

--- a/test/parser/mysql/syntax/ddl.test.ts
+++ b/test/parser/mysql/syntax/ddl.test.ts
@@ -1,4 +1,4 @@
-import MySQL from '../../../../src/parser/mysql';
+import { MySQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new MySQL();

--- a/test/parser/mysql/syntax/dml.test.ts
+++ b/test/parser/mysql/syntax/dml.test.ts
@@ -1,4 +1,4 @@
-import MySQL from '../../../../src/parser/mysql';
+import { MySQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new MySQL();

--- a/test/parser/mysql/syntax/other.test.ts
+++ b/test/parser/mysql/syntax/other.test.ts
@@ -1,4 +1,4 @@
-import MySQL from '../../../../src/parser/mysql';
+import { MySQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new MySQL();

--- a/test/parser/mysql/visitor.test.ts
+++ b/test/parser/mysql/visitor.test.ts
@@ -1,6 +1,4 @@
-import MySQL from '../../../src/parser/mysql';
-import { MySqlParserVisitor } from '../../../src/lib/mysql/MySqlParserVisitor';
-import { AbstractParseTreeVisitor } from 'antlr4ts/tree';
+import { MySQL, MySqlParserVisitor, AbstractParseTreeVisitor } from '../../filters';
 
 describe('MySQL Visitor Tests', () => {
     const expectTableName = 'user1';

--- a/test/parser/pgsql/errorStrategy.test.ts
+++ b/test/parser/pgsql/errorStrategy.test.ts
@@ -1,6 +1,4 @@
-import PgSQL from '../../../src/parser/pgsql';
-import { PgSqlSplitListener } from '../../../src/parser/pgsql';
-import { PostgreSQLParserListener } from '../../../src/lib/pgsql/PostgreSQLParserListener';
+import { PostgresSQL, PgSqlSplitListener, PostgreSQLParserListener } from '../../filters';
 
 const validSQL1 = `INSERT INTO country_page_view
 VALUES ('Chinese', 'mumiao', 18),
@@ -9,7 +7,7 @@ const validSQL2 = 'SELECT * FROM tb;';
 const inValidSQL = 'CREATE TABLE';
 
 describe('PgSQL ErrorStrategy test', () => {
-    const pgSQL = new PgSQL();
+    const pgSQL = new PostgresSQL();
 
     // TODO: handle unexpected case
     // test('begin inValid', () => {

--- a/test/parser/pgsql/lexer.test.ts
+++ b/test/parser/pgsql/lexer.test.ts
@@ -1,4 +1,4 @@
-import PostgresSQL from '../../../src/parser/pgsql';
+import { PostgresSQL } from '../../filters';
 
 describe('PostgresSQL Lexer tests', () => {
     const mysqlParser = new PostgresSQL();

--- a/test/parser/pgsql/listener.test.ts
+++ b/test/parser/pgsql/listener.test.ts
@@ -1,6 +1,4 @@
-import { ParseTreeListener } from 'antlr4ts/tree';
-import { PostgreSQLParserListener } from '../../../src/lib/pgsql/PostgreSQLParserListener';
-import PostgresSQL from '../../../src/parser/pgsql';
+import { PostgresSQL, PostgreSQLParserListener, ParseTreeListener } from '../../filters';
 
 describe('PostgresSQL Listener Tests', () => {
     const expectTableName = 'user1';

--- a/test/parser/pgsql/suggestion/multipleStatement.test.ts
+++ b/test/parser/pgsql/suggestion/multipleStatement.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition, SyntaxContextType } from '../../../../src/parser/common/basic-parser-types';
-import PgSQL from '../../../../src/parser/pgsql';
+import { CaretPosition, SyntaxContextType, PostgresSQL } from '../../../filters';
 
 const syntaxSql = fs.readFileSync(
     path.join(__dirname, 'fixtures', 'multipleStatement.sql'),
@@ -9,7 +8,7 @@ const syntaxSql = fs.readFileSync(
 );
 
 describe('PgSQL Multiple Statements Syntax Suggestion', () => {
-    const parser = new PgSQL();
+    const parser = new PostgresSQL();
 
     test('Create table ', () => {
         const pos: CaretPosition = {

--- a/test/parser/pgsql/suggestion/syntaxSuggestion.test.ts
+++ b/test/parser/pgsql/suggestion/syntaxSuggestion.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition, SyntaxContextType } from '../../../../src/parser/common/basic-parser-types';
-import PgSQL from '../../../../src/parser/pgsql';
+import { PostgresSQL, CaretPosition, SyntaxContextType } from '../../../filters';
 import { commentOtherLine } from '../../../helper';
 
 const syntaxSql = fs.readFileSync(
@@ -10,7 +9,7 @@ const syntaxSql = fs.readFileSync(
 );
 
 describe('Postgre SQL Syntax Suggestion', () => {
-    const parser = new PgSQL();
+    const parser = new PostgresSQL();
 
     test('Validate Syntax SQL', () => {
         expect(parser.validate(syntaxSql).length).not.toBe(0);

--- a/test/parser/pgsql/suggestion/tokenSuggestion.test.ts
+++ b/test/parser/pgsql/suggestion/tokenSuggestion.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition } from '../../../../src/parser/common/basic-parser-types';
-import PostgresSQL from '../../../../src/parser/pgsql';
+import { PostgresSQL, CaretPosition } from '../../../filters';
 import { commentOtherLine } from '../../../helper';
 
 const tokenSql = fs.readFileSync(path.join(__dirname, 'fixtures', 'tokenSuggestion.sql'), 'utf-8');

--- a/test/parser/pgsql/syntax/alterStatement.test.ts
+++ b/test/parser/pgsql/syntax/alterStatement.test.ts
@@ -1,7 +1,7 @@
-import PgSQL from '../../../../src/parser/pgsql';
+import { PostgresSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
-const parser = new PgSQL();
+const parser = new PostgresSQL();
 
 const features = {
     alters: readSQL(__dirname, 'alter.sql'),

--- a/test/parser/pgsql/syntax/createStatement.test.ts
+++ b/test/parser/pgsql/syntax/createStatement.test.ts
@@ -1,7 +1,7 @@
-import PgSQL from '../../../../src/parser/pgsql';
+import { PostgresSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
-const parser = new PgSQL();
+const parser = new PostgresSQL();
 
 const features = {
     creates: readSQL(__dirname, 'create.sql'),

--- a/test/parser/pgsql/syntax/deleteStatement.test.ts
+++ b/test/parser/pgsql/syntax/deleteStatement.test.ts
@@ -1,7 +1,7 @@
-import PgSQL from '../../../../src/parser/pgsql';
+import { PostgresSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
-const parser = new PgSQL();
+const parser = new PostgresSQL();
 
 const features = {
     deletes: readSQL(__dirname, 'delete.sql'),

--- a/test/parser/pgsql/syntax/dropStatement.test.ts
+++ b/test/parser/pgsql/syntax/dropStatement.test.ts
@@ -1,7 +1,7 @@
-import PgSQL from '../../../../src/parser/pgsql';
+import { PostgresSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
-const parser = new PgSQL();
+const parser = new PostgresSQL();
 
 const features = {
     drops: readSQL(__dirname, 'drop.sql'),

--- a/test/parser/pgsql/syntax/insertStatement.test.ts
+++ b/test/parser/pgsql/syntax/insertStatement.test.ts
@@ -1,7 +1,7 @@
-import PgSQL from '../../../../src/parser/pgsql';
+import { PostgresSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
-const parser = new PgSQL();
+const parser = new PostgresSQL();
 
 const features = {
     inserts: readSQL(__dirname, 'insert.sql'),

--- a/test/parser/pgsql/syntax/others.test.ts
+++ b/test/parser/pgsql/syntax/others.test.ts
@@ -1,7 +1,7 @@
-import PgSQL from '../../../../src/parser/pgsql';
+import { PostgresSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
-const parser = new PgSQL();
+const parser = new PostgresSQL();
 
 const features = {
     others: readSQL(__dirname, 'others.sql'),

--- a/test/parser/pgsql/syntax/selectStatement.test.ts
+++ b/test/parser/pgsql/syntax/selectStatement.test.ts
@@ -1,7 +1,7 @@
-import PgSQL from '../../../../src/parser/pgsql';
+import { PostgresSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
-const parser = new PgSQL();
+const parser = new PostgresSQL();
 
 const features = {
     selects: readSQL(__dirname, 'select.sql'),

--- a/test/parser/pgsql/syntax/updateStatement.test.ts
+++ b/test/parser/pgsql/syntax/updateStatement.test.ts
@@ -1,7 +1,7 @@
-import PgSQL from '../../../../src/parser/pgsql';
+import { PostgresSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
-const parser = new PgSQL();
+const parser = new PostgresSQL();
 
 const features = {
     updates: readSQL(__dirname, 'update.sql'),

--- a/test/parser/pgsql/visitor.test.ts
+++ b/test/parser/pgsql/visitor.test.ts
@@ -1,6 +1,4 @@
-import { AbstractParseTreeVisitor } from 'antlr4ts/tree/AbstractParseTreeVisitor';
-import { PostgreSQLParserVisitor } from '../../../src/lib/pgsql/PostgreSQLParserVisitor';
-import PostgresSQL from '../../../src/parser/pgsql';
+import { PostgresSQL, AbstractParseTreeVisitor, PostgreSQLParserVisitor } from '../../filters';
 
 describe('MySQL Visitor Tests', () => {
     const expectTableName = 'user1';

--- a/test/parser/plsql/lexer.test.ts
+++ b/test/parser/plsql/lexer.test.ts
@@ -1,4 +1,4 @@
-import PLSQL from '../../../src/parser/plsql';
+import { PLSQL } from '../../filters';
 
 describe('PLSQL Lexer tests', () => {
     const parser = new PLSQL();

--- a/test/parser/plsql/listener.test.ts
+++ b/test/parser/plsql/listener.test.ts
@@ -1,6 +1,4 @@
-import { ParseTreeListener } from 'antlr4ts/tree';
-import { PlSqlParserListener } from '../../../src/lib/plsql/PlSqlParserListener';
-import PLSQL from '../../../src/parser/plsql';
+import { PLSQL, PlSqlParserListener, ParseTreeListener } from '../../filters';
 
 describe('PLSQL Listener Tests', () => {
     const expectTableName = 'user1';

--- a/test/parser/plsql/syntax.test.ts
+++ b/test/parser/plsql/syntax.test.ts
@@ -1,7 +1,7 @@
-import PLSQLParser from '../../../src/parser/plsql';
+import { PLSQL } from '../../filters';
 
 describe('PLSQL Syntax Tests', () => {
-    const parser = new PLSQLParser();
+    const parser = new PLSQL();
 
     test('Test simple select Statement', () => {
         const sql = 'select id,name from user1;';

--- a/test/parser/plsql/visitor.test.ts
+++ b/test/parser/plsql/visitor.test.ts
@@ -1,6 +1,4 @@
-import { AbstractParseTreeVisitor } from 'antlr4ts/tree/AbstractParseTreeVisitor';
-import { PlSqlParserVisitor } from '../../../src/lib/plsql/PlSqlParserVisitor';
-import PLSQL from '../../../src/parser/plsql';
+import { PLSQL, AbstractParseTreeVisitor, PlSqlParserVisitor } from '../../filters';
 
 describe('PLSQL Visitor Tests', () => {
     const expectTableName = 'user1';

--- a/test/parser/spark/errorStrategy.test.ts
+++ b/test/parser/spark/errorStrategy.test.ts
@@ -1,6 +1,4 @@
-import SparkSQL from '../../../src/parser/spark';
-import { SparkSqlSplitListener } from '../../../src/parser/spark';
-import { SparkSqlParserListener } from '../../../src/lib/spark/SparkSqlParserListener';
+import { SparkSQL, SparkSqlSplitListener, SparkSqlParserListener } from '../../filters';
 
 const validSQL1 = `INSERT INTO country_page_view
 VALUES ('Chinese', 'mumiao', 18),

--- a/test/parser/spark/lexer.test.ts
+++ b/test/parser/spark/lexer.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../src/parser/spark';
+import { SparkSQL } from '../../filters';
 
 describe('SparkSQL Lexer tests', () => {
     const parser = new SparkSQL();

--- a/test/parser/spark/listener.test.ts
+++ b/test/parser/spark/listener.test.ts
@@ -1,6 +1,4 @@
-import { ParseTreeListener } from 'antlr4ts/tree';
-import { SparkSqlParserListener } from '../../../src/lib/spark/SparkSqlParserListener';
-import SparkSQL from '../../../src/parser/spark';
+import { SparkSQL, ParseTreeListener, SparkSqlParserListener } from '../../filters';
 
 describe('Spark SQL Listener Tests', () => {
     const expectTableName = 'user1';

--- a/test/parser/spark/suggestion/multipleStatement.test.ts
+++ b/test/parser/spark/suggestion/multipleStatement.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition, SyntaxContextType } from '../../../../src/parser/common/basic-parser-types';
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL, CaretPosition, SyntaxContextType } from '../../../filters';
 
 const syntaxSql = fs.readFileSync(
     path.join(__dirname, 'fixtures', 'multipleStatement.sql'),

--- a/test/parser/spark/suggestion/syntaxSuggestion.test.ts
+++ b/test/parser/spark/suggestion/syntaxSuggestion.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition, SyntaxContextType } from '../../../../src/parser/common/basic-parser-types';
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL, CaretPosition, SyntaxContextType } from '../../../filters';
 import { commentOtherLine } from '../../../helper';
 
 const syntaxSql = fs.readFileSync(

--- a/test/parser/spark/suggestion/tokenSuggestion.test.ts
+++ b/test/parser/spark/suggestion/tokenSuggestion.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition } from '../../../../src/parser/common/basic-parser-types';
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL, CaretPosition } from '../../../filters';
 import { commentOtherLine } from '../../../helper';
 
 const tokenSql = fs.readFileSync(path.join(__dirname, 'fixtures', 'tokenSuggestion.sql'), 'utf-8');

--- a/test/parser/spark/syntax/addStatement.test.ts
+++ b/test/parser/spark/syntax/addStatement.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/alert.test.ts
+++ b/test/parser/spark/syntax/alert.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/analyzeTableStatement.test.ts
+++ b/test/parser/spark/syntax/analyzeTableStatement.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/cacheStatement.test.ts
+++ b/test/parser/spark/syntax/cacheStatement.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/create.test.ts
+++ b/test/parser/spark/syntax/create.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/describeStatement.test.ts
+++ b/test/parser/spark/syntax/describeStatement.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/drop.test.ts
+++ b/test/parser/spark/syntax/drop.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/insertStatement.test.ts
+++ b/test/parser/spark/syntax/insertStatement.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/kwMultipleValues.test.ts
+++ b/test/parser/spark/syntax/kwMultipleValues.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/listStatement.test.ts
+++ b/test/parser/spark/syntax/listStatement.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/loadStatement.test.ts
+++ b/test/parser/spark/syntax/loadStatement.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/refreshStatement.test.ts
+++ b/test/parser/spark/syntax/refreshStatement.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/resetStatement.test.ts
+++ b/test/parser/spark/syntax/resetStatement.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/selectStatement.test.ts
+++ b/test/parser/spark/syntax/selectStatement.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/setStatement.test.ts
+++ b/test/parser/spark/syntax/setStatement.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/showStatement.test.ts
+++ b/test/parser/spark/syntax/showStatement.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/table.test.ts
+++ b/test/parser/spark/syntax/table.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/syntax/useDatabase.test.ts
+++ b/test/parser/spark/syntax/useDatabase.test.ts
@@ -1,4 +1,4 @@
-import SparkSQL from '../../../../src/parser/spark';
+import { SparkSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const parser = new SparkSQL();

--- a/test/parser/spark/visitor.test.ts
+++ b/test/parser/spark/visitor.test.ts
@@ -1,6 +1,4 @@
-import { AbstractParseTreeVisitor } from 'antlr4ts/tree/AbstractParseTreeVisitor';
-import { SparkSqlParserVisitor } from '../../../src/lib/spark/SparkSqlParserVisitor';
-import SparkSQL from '../../../src/parser/spark';
+import { SparkSQL, SparkSqlParserVisitor, AbstractParseTreeVisitor } from '../../filters';
 
 describe('Spark SQL Visitor Tests', () => {
     const expectTableName = 'user1';

--- a/test/parser/trinosql/errorStrategy.test.ts
+++ b/test/parser/trinosql/errorStrategy.test.ts
@@ -1,6 +1,4 @@
-import TrinoSQL from '../../../src/parser/trinosql';
-import { TrinoSqlSplitListener } from '../../../src/parser/trinosql';
-import { TrinoSqlListener } from '../../../src/lib/trinosql/TrinoSqlListener';
+import { TrinoSQL, TrinoSqlSplitListener, TrinoSqlListener } from '../../filters';
 
 const validSQL1 = `INSERT INTO country_page_view
 VALUES ('Chinese', 'mumiao', 18),

--- a/test/parser/trinosql/lexer.test.ts
+++ b/test/parser/trinosql/lexer.test.ts
@@ -1,7 +1,7 @@
-import trinoSQL from '../../../src/parser/trinosql';
+import { TrinoSQL } from '../../filters';
 
 describe('trinoSQL Lexer tests', () => {
-    const parser = new trinoSQL();
+    const parser = new TrinoSQL();
 
     const sql = 'SELECT * FROM table1';
     const tokens = parser.getAllTokens(sql);

--- a/test/parser/trinosql/listener.test.ts
+++ b/test/parser/trinosql/listener.test.ts
@@ -1,11 +1,9 @@
-import trinoSQL from '../../../src/parser/trinosql';
-import { TrinoSqlListener } from '../../../src/lib/trinosql/TrinoSqlListener';
-import { ParseTreeListener } from 'antlr4ts/tree';
+import { TrinoSQL, TrinoSqlListener, ParseTreeListener } from '../../filters';
 
 describe('trino SQL Listener Tests', () => {
     const expectTableName = 'user1';
     const sql = `select id,name,sex from ${expectTableName};`;
-    const parser = new trinoSQL();
+    const parser = new TrinoSQL();
 
     const parseTree = parser.parse(sql);
 

--- a/test/parser/trinosql/suggestion/multipleStatement.test.ts
+++ b/test/parser/trinosql/suggestion/multipleStatement.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition, SyntaxContextType } from '../../../../src/parser/common/basic-parser-types';
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL, CaretPosition, SyntaxContextType } from '../../../filters';
 
 const syntaxSql = fs.readFileSync(
     path.join(__dirname, 'fixtures', 'multipleStatement.sql'),

--- a/test/parser/trinosql/suggestion/syntaxSuggestion.test.ts
+++ b/test/parser/trinosql/suggestion/syntaxSuggestion.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition, SyntaxContextType } from '../../../../src/parser/common/basic-parser-types';
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL, CaretPosition, SyntaxContextType } from '../../../filters';
 import { commentOtherLine } from '../../../helper';
 
 const syntaxSql = fs.readFileSync(

--- a/test/parser/trinosql/suggestion/tokenSuggestion.test.ts
+++ b/test/parser/trinosql/suggestion/tokenSuggestion.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { CaretPosition } from '../../../../src/parser/common/basic-parser-types';
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL, CaretPosition } from '../../../filters';
 import { commentOtherLine } from '../../../helper';
 
 const tokenSql = fs.readFileSync(path.join(__dirname, 'fixtures', 'tokenSuggestion.sql'), 'utf-8');

--- a/test/parser/trinosql/syntax/alterStatement.test.ts
+++ b/test/parser/trinosql/syntax/alterStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/analyzeStatement.test.ts
+++ b/test/parser/trinosql/syntax/analyzeStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/callStatement.test.ts
+++ b/test/parser/trinosql/syntax/callStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/commentStatement.test.ts
+++ b/test/parser/trinosql/syntax/commentStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/commitStatement.test.ts
+++ b/test/parser/trinosql/syntax/commitStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/createStatement.test.ts
+++ b/test/parser/trinosql/syntax/createStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/deallocatePrepareStatement.test.ts
+++ b/test/parser/trinosql/syntax/deallocatePrepareStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/deleteStatement.test.ts
+++ b/test/parser/trinosql/syntax/deleteStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/denyStatement.test.ts
+++ b/test/parser/trinosql/syntax/denyStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/describeStatement.test.ts
+++ b/test/parser/trinosql/syntax/describeStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/dropStatement.test.ts
+++ b/test/parser/trinosql/syntax/dropStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/executeStatement.test.ts
+++ b/test/parser/trinosql/syntax/executeStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/explainStatement.test.ts
+++ b/test/parser/trinosql/syntax/explainStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/grantStatement.test.ts
+++ b/test/parser/trinosql/syntax/grantStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/insertStatement.test.ts
+++ b/test/parser/trinosql/syntax/insertStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/matchRecognizeStatement.test.ts
+++ b/test/parser/trinosql/syntax/matchRecognizeStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/merge.test.ts
+++ b/test/parser/trinosql/syntax/merge.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/prepareStatement.test.ts
+++ b/test/parser/trinosql/syntax/prepareStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/refreshMaterializedViewStatement.test.ts
+++ b/test/parser/trinosql/syntax/refreshMaterializedViewStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/resetSessionStatement.test.ts
+++ b/test/parser/trinosql/syntax/resetSessionStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/revokeStatement.test.ts
+++ b/test/parser/trinosql/syntax/revokeStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/rollbackTransactionStatement.test.ts
+++ b/test/parser/trinosql/syntax/rollbackTransactionStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/selectStatement.test.ts
+++ b/test/parser/trinosql/syntax/selectStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/setStatement.test.ts
+++ b/test/parser/trinosql/syntax/setStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/showStatement.test.ts
+++ b/test/parser/trinosql/syntax/showStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/startTransactionStatement.test.ts
+++ b/test/parser/trinosql/syntax/startTransactionStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/truncateTableStatement.test.ts
+++ b/test/parser/trinosql/syntax/truncateTableStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/updateStatement.test.ts
+++ b/test/parser/trinosql/syntax/updateStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/useStatement.test.ts
+++ b/test/parser/trinosql/syntax/useStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/valuesStatement.test.ts
+++ b/test/parser/trinosql/syntax/valuesStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/syntax/windowWithRowPatternRecognitionStatement.test.ts
+++ b/test/parser/trinosql/syntax/windowWithRowPatternRecognitionStatement.test.ts
@@ -1,4 +1,4 @@
-import TrinoSQL from '../../../../src/parser/trinosql';
+import { TrinoSQL } from '../../../filters';
 import { readSQL } from '../../../helper';
 
 const features = {

--- a/test/parser/trinosql/visitor.test.ts
+++ b/test/parser/trinosql/visitor.test.ts
@@ -1,11 +1,9 @@
-import trinoSQL from '../../../src/parser/trinosql';
-import { TrinoSqlVisitor } from '../../../src/lib/trinosql/TrinoSqlVisitor';
-import { AbstractParseTreeVisitor } from 'antlr4ts/tree';
+import { TrinoSQL, TrinoSqlVisitor, AbstractParseTreeVisitor } from '../../filters';
 
 describe('trino SQL Visitor Tests', () => {
     const expectTableName = 'user1';
     const sql = `select id,name,sex from ${expectTableName};`;
-    const parser = new trinoSQL();
+    const parser = new TrinoSQL();
 
     const parseTree = parser.parse(sql, (error) => {
         console.log('Parse error:', error);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,11 +12,6 @@
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
         "skipLibCheck": true,
-        "paths": {
-            "antlr4": [
-                "./node_modules/antlr4/src/antlr4/index"
-            ]
-        },
         "types": [
             "node",
             "jest"
@@ -27,6 +22,7 @@
             "./src/typings"
         ]
     },
+    "isolatedModules": true,
     "include": [
         "./src/**/*"
     ],


### PR DESCRIPTION
## 主要变更
1. 新增导出 `AbstractParseTreeVisitor` 以修复 #236 
2. `export *` 变更为具名导出
3. tsconfig.json 开启 `isolatedModules` 选项，以及删除 path 配置（无意义的配置）
4. 单测文件中有关 parser 的 import 统一从 `test/filters` 文件夹下导入

### 为什么一定要具名导出
实际上 `export * ` 对于一个库来说是比较危险的，这会让项目内的导出变得难以管理。

### 为什么开启 `isolatedModules` 选项
在上述关于单测的改动完成后，发现单元测试运行前，内部的前置准备（模块解析、ts编译等）需要很长时间（6分钟还没有开始正式运行），并且此前单元测试运行时也经常会有 Babel Exceed 500K 的警告。使用[ jest issue#11234 ](https://github.com/jestjs/jest/issues/11234) 中提到的方法，开启 `isolatedModules` 选项，单元测试运行速度明显变快。

### 为什么更改单测文件中的导入？
这是为了保证以后不再发生此类问题，如果忘记在入口文件中导出某个本来应该导出的，那么在单元测试中也无法使用，这能使我们更快且更早的发现此类问题。
