### PR TITLE
fix: #285 No longer just export types from libs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export {
     PLSQL,
 } from './parser';
 
-export type {
+export {
     MySqlParserListener,
     MySqlParserVisitor,
     FlinkSqlParserListener,


### PR DESCRIPTION
## 主要变更

入口文件中， 不再仅导出 visitor 和 listener 的 type