### PR TITLE
feat: complete after error syntax

### DIFF
--- a/src/parser/common/basicSQL.ts
+++ b/src/parser/common/basicSQL.ts
@@ -215,28 +215,6 @@ export abstract class BasicSQL<
     }
 
     /**
-     * Get the parseTree of the input string.
-     * @param input source string
-     * @returns parse and parserTree
-     */
-    private parserWithNewInput(inputSlice: string) {
-        const lexer = this.createLexer(inputSlice);
-        lexer.removeErrorListeners();
-        const tokenStream = new CommonTokenStream(lexer);
-        tokenStream.fill();
-        const parser = this.createParserFromTokenStream(tokenStream);
-        parser.interpreter.predictionMode = PredictionMode.SLL;
-        parser.removeErrorListeners();
-        parser.buildParseTrees = true;
-        parser.errorHandler = new ErrorStrategy();
-
-        return {
-            sqlParserIns: parser,
-            parseTree: parser.program(),
-        };
-    }
-
-    /**
      * Validate input string and return syntax errors if exists.
      * @param input source string
      * @returns syntax errors
@@ -487,11 +465,8 @@ export abstract class BasicSQL<
          * and c3 will collect candidates in the newly generated parseTree when input changed.
          */
         if (inputSlice !== input) {
-            const { sqlParserIns: _sqlParserIns, parseTree: _parseTree } =
-                this.parserWithNewInput(inputSlice);
-
-            sqlParserIns = _sqlParserIns;
-            parseTree = _parseTree;
+            sqlParserIns = this.createParser(inputSlice);
+            parseTree = sqlParserIns.program();
         }
 
         return {
@@ -556,11 +531,8 @@ export abstract class BasicSQL<
          * and c3 will collect candidates in the newly generated parseTree when input changed.
          */
         if (inputSlice !== input) {
-            const { sqlParserIns: _sqlParserIns, parseTree: _parseTree } =
-                this.parserWithNewInput(inputSlice);
-
-            sqlParserIns = _sqlParserIns;
-            parseTree = _parseTree;
+            sqlParserIns = this.createParser(inputSlice);
+            parseTree = sqlParserIns.program();
         }
 
         const core = new CodeCompletionCore(sqlParserIns);

--- a/src/parser/common/semanticContextCollector.ts
+++ b/src/parser/common/semanticContextCollector.ts
@@ -6,8 +6,7 @@ import {
     SemanticContext,
     SqlSplitStrategy,
 } from '../common/types';
-
-export const SQL_SPLIT_SYMBOL_TEXT = ';';
+import { SQL_SPLIT_SYMBOL_TEXT } from './basicSQL';
 
 abstract class SemanticContextCollector {
     constructor(

--- a/test/parser/flink/suggestion/completeAfterSyntaxError.test.ts
+++ b/test/parser/flink/suggestion/completeAfterSyntaxError.test.ts
@@ -1,0 +1,65 @@
+import { FlinkSQL } from 'src/parser/flink';
+import { CaretPosition, EntityContextType } from 'src/parser/common/types';
+
+describe('FlinkSQL Complete After Syntax Error', () => {
+    const flink = new FlinkSQL();
+
+    const sql1 = `SELECT  FROM tb2;\nINSERT INTO `;
+    const sql2 = `SELECT  FROM tb3;\nCREATE TABLE `;
+    const sql3 = `SELECT FROM t1;\nSL`;
+
+    test('Syntax error but end with semi, should suggest tableName', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 13,
+        };
+        const suggestion = flink.getSuggestionAtCaretPosition(sql1, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(1);
+        expect(syntaxes[0].syntaxContextType).toBe(EntityContextType.TABLE);
+
+        // keyword
+        const keywords = suggestion?.keywords;
+        expect(keywords.length).toBe(0);
+    });
+
+    test('Syntax error but end with semi, should suggest tableNameCreate', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 14,
+        };
+        const suggestion = flink.getSuggestionAtCaretPosition(sql2, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(1);
+        expect(syntaxes[0].syntaxContextType).toBe(EntityContextType.TABLE_CREATE);
+
+        // keyword
+        const keywords = suggestion?.keywords;
+        expect(keywords).toMatchUnorderedArray(['IF', 'IF NOT EXISTS']);
+    });
+
+    test('Syntax error but end with semi, should suggest filter token', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 2,
+        };
+        const suggestion = flink.getSuggestionAtCaretPosition(sql3, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(0);
+
+        // keyword
+        const filterKeywords = suggestion?.keywords?.filter(
+            (item) => item.startsWith('S') && /S(?=.*L)/.test(item)
+        );
+        expect(filterKeywords).toMatchUnorderedArray(['SELECT']);
+    });
+});

--- a/test/parser/hive/suggestion/completeAfterSyntaxError.test.ts
+++ b/test/parser/hive/suggestion/completeAfterSyntaxError.test.ts
@@ -1,0 +1,66 @@
+import { HiveSQL } from 'src/parser/hive';
+import { CaretPosition, EntityContextType } from 'src/parser/common/types';
+
+describe('HiveSQL Complete After Syntax Error', () => {
+    const hive = new HiveSQL();
+
+    const sql1 = `SELECT  FROM tb2;\nINSERT INTO `;
+    const sql2 = `SELECT  FROM tb3;\nCREATE TABLE `;
+    const sql3 = `SELECT FROM t1;\nSL`;
+
+    test('Syntax error but end with semi, should suggest tableName', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 13,
+        };
+        const suggestion = hive.getSuggestionAtCaretPosition(sql1, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(1);
+        expect(syntaxes[0].syntaxContextType).toBe(EntityContextType.TABLE);
+
+        // keyword
+        const keywords = suggestion?.keywords;
+        expect(keywords.length).toBe(1);
+        expect(keywords[0]).toBe('TABLE');
+    });
+
+    test('Syntax error but end with semi, should suggest tableNameCreate', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 14,
+        };
+        const suggestion = hive.getSuggestionAtCaretPosition(sql2, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(1);
+        expect(syntaxes[0].syntaxContextType).toBe(EntityContextType.TABLE_CREATE);
+
+        // keyword
+        const keywords = suggestion?.keywords;
+        expect(keywords).toMatchUnorderedArray(['IF', 'IF NOT EXISTS']);
+    });
+
+    test('Syntax error but end with semi, should suggest filter token', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 2,
+        };
+        const suggestion = hive.getSuggestionAtCaretPosition(sql3, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(0);
+
+        // keyword
+        const filterKeywords = suggestion?.keywords?.filter(
+            (item) => item.startsWith('S') && /S(?=.*L)/.test(item)
+        );
+        expect(filterKeywords).toMatchUnorderedArray(['SELECT']);
+    });
+});

--- a/test/parser/impala/suggestion/completeAfterSyntaxError.test.ts
+++ b/test/parser/impala/suggestion/completeAfterSyntaxError.test.ts
@@ -1,0 +1,66 @@
+import { ImpalaSQL } from 'src/parser/impala';
+import { CaretPosition, EntityContextType } from 'src/parser/common/types';
+
+describe('ImpalaSQL Complete After Syntax Error', () => {
+    const impala = new ImpalaSQL();
+
+    const sql1 = `SELECT  FROM tb2;\nINSERT INTO `;
+    const sql2 = `SELECT  FROM tb3;\nCREATE TABLE `;
+    const sql3 = `SELECT FROM t1;\nSL`;
+
+    test('Syntax error but end with semi, should suggest tableName', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 13,
+        };
+        const suggestion = impala.getSuggestionAtCaretPosition(sql1, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(1);
+        expect(syntaxes[0].syntaxContextType).toBe(EntityContextType.TABLE);
+
+        // keyword
+        const keywords = suggestion?.keywords;
+        expect(keywords.length).toBe(1);
+        expect(keywords[0]).toBe('TABLE');
+    });
+
+    test('Syntax error but end with semi, should suggest tableNameCreate', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 14,
+        };
+        const suggestion = impala.getSuggestionAtCaretPosition(sql2, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(1);
+        expect(syntaxes[0].syntaxContextType).toBe(EntityContextType.TABLE_CREATE);
+
+        // keyword
+        const keywords = suggestion?.keywords;
+        expect(keywords).toMatchUnorderedArray(['IF', 'IF NOT EXISTS']);
+    });
+
+    test('Syntax error but end with semi, should suggest filter token', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 2,
+        };
+        const suggestion = impala.getSuggestionAtCaretPosition(sql3, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(0);
+
+        // keyword
+        const filterKeywords = suggestion?.keywords?.filter(
+            (item) => item.startsWith('S') && /S(?=.*L)/.test(item)
+        );
+        expect(filterKeywords).toMatchUnorderedArray(['SELECT']);
+    });
+});

--- a/test/parser/mysql/suggestion/completeAfterSyntaxError.test.ts
+++ b/test/parser/mysql/suggestion/completeAfterSyntaxError.test.ts
@@ -1,0 +1,65 @@
+import { MySQL } from 'src/parser/mysql';
+import { CaretPosition, EntityContextType } from 'src/parser/common/types';
+
+describe('MySQL Complete After Syntax Error', () => {
+    const mysql = new MySQL();
+
+    const sql1 = `SELECT  FROM tb2;\nINSERT INTO `;
+    const sql2 = `SELECT  FROM tb3;\nCREATE TABLE `;
+    const sql3 = `SELECT FROM t1;\nSL`;
+
+    test('Syntax error but end with semi, should suggest tableName', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 13,
+        };
+        const suggestion = mysql.getSuggestionAtCaretPosition(sql1, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(1);
+        expect(syntaxes[0].syntaxContextType).toBe(EntityContextType.TABLE);
+
+        // keyword
+        const keywords = suggestion?.keywords;
+        expect(keywords.length).toBe(0);
+    });
+
+    test('Syntax error but end with semi, should suggest tableNameCreate', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 14,
+        };
+        const suggestion = mysql.getSuggestionAtCaretPosition(sql2, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(1);
+        expect(syntaxes[0].syntaxContextType).toBe(EntityContextType.TABLE_CREATE);
+
+        // keyword
+        const keywords = suggestion?.keywords;
+        expect(keywords).toMatchUnorderedArray(['IF', 'IF NOT EXISTS']);
+    });
+
+    test('Syntax error but end with semi, should suggest filter token', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 2,
+        };
+        const suggestion = mysql.getSuggestionAtCaretPosition(sql3, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(0);
+
+        // keyword
+        const filterKeywords = suggestion?.keywords?.filter(
+            (item) => item.startsWith('S') && /S(?=.*L)/.test(item)
+        );
+        expect(filterKeywords).toMatchUnorderedArray(['SELECT', 'SIGNAL']);
+    });
+});

--- a/test/parser/postgresql/suggestion/completeAfterSyntaxError.test.ts
+++ b/test/parser/postgresql/suggestion/completeAfterSyntaxError.test.ts
@@ -1,0 +1,65 @@
+import { PostgreSQL } from 'src/parser/postgresql';
+import { CaretPosition, EntityContextType } from 'src/parser/common/types';
+
+describe('PostgreSQL Complete After Syntax Error', () => {
+    const postgresql = new PostgreSQL();
+
+    const sql1 = `SELECT  FROM tb2;\nINSERT INTO `;
+    const sql2 = `SELECT  FROM tb3;\nCREATE TABLE `;
+    const sql3 = `SELECT FROM t1;\nSL`;
+
+    test('Syntax error but end with semi, should suggest tableName', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 13,
+        };
+        const suggestion = postgresql.getSuggestionAtCaretPosition(sql1, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(1);
+        expect(syntaxes[0].syntaxContextType).toBe(EntityContextType.TABLE);
+
+        // keyword
+        const keywords = suggestion?.keywords;
+        expect(keywords.length).toBe(0);
+    });
+
+    test('Syntax error but end with semi, should suggest tableNameCreate', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 14,
+        };
+        const suggestion = postgresql.getSuggestionAtCaretPosition(sql2, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(1);
+        expect(syntaxes[0].syntaxContextType).toBe(EntityContextType.TABLE_CREATE);
+
+        // keyword
+        const keywords = suggestion?.keywords;
+        expect(keywords).toMatchUnorderedArray(['IF', 'IF NOT EXISTS']);
+    });
+
+    test('Syntax error but end with semi, should suggest filter token', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 2,
+        };
+        const suggestion = postgresql.getSuggestionAtCaretPosition(sql3, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(0);
+
+        // keyword
+        const filterKeywords = suggestion?.keywords?.filter(
+            (item) => item.startsWith('SEL') && /S(?=.*L)/.test(item)
+        );
+        expect(filterKeywords).toMatchUnorderedArray(['SELECT']);
+    });
+});

--- a/test/parser/spark/suggestion/completeAfterSyntaxError.test.ts
+++ b/test/parser/spark/suggestion/completeAfterSyntaxError.test.ts
@@ -1,0 +1,66 @@
+import { SparkSQL } from 'src/parser/spark';
+import { CaretPosition, EntityContextType } from 'src/parser/common/types';
+
+describe('SparkSQL Complete After Syntax Error', () => {
+    const spark = new SparkSQL();
+
+    const sql1 = `SELECT  FROM tb2;\nINSERT INTO `;
+    const sql2 = `SELECT  FROM tb3;\nCREATE TABLE `;
+    const sql3 = `SELECT FROM t1;\nSL`;
+
+    test('Syntax error but end with semi, should suggest tableName', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 13,
+        };
+        const suggestion = spark.getSuggestionAtCaretPosition(sql1, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(1);
+        expect(syntaxes[0].syntaxContextType).toBe(EntityContextType.TABLE);
+
+        // keyword
+        const keywords = suggestion?.keywords;
+        expect(keywords.length).toBe(1);
+        expect(keywords[0]).toBe('TABLE');
+    });
+
+    test('Syntax error but end with semi, should suggest tableNameCreate', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 14,
+        };
+        const suggestion = spark.getSuggestionAtCaretPosition(sql2, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(1);
+        expect(syntaxes[0].syntaxContextType).toBe(EntityContextType.TABLE_CREATE);
+
+        // keyword
+        const keywords = suggestion?.keywords;
+        expect(keywords).toMatchUnorderedArray(['IF', 'IF NOT EXISTS']);
+    });
+
+    test('Syntax error but end with semi, should suggest filter token', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 2,
+        };
+        const suggestion = spark.getSuggestionAtCaretPosition(sql3, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(0);
+
+        // keyword
+        const filterKeywords = suggestion?.keywords?.filter(
+            (item) => item.startsWith('S') && /S(?=.*L)/.test(item)
+        );
+        expect(filterKeywords).toMatchUnorderedArray(['SELECT']);
+    });
+});

--- a/test/parser/trino/suggestion/completeAfterSyntaxError.test.ts
+++ b/test/parser/trino/suggestion/completeAfterSyntaxError.test.ts
@@ -1,0 +1,65 @@
+import { TrinoSQL } from 'src/parser/trino';
+import { CaretPosition, EntityContextType } from 'src/parser/common/types';
+
+describe('TrinoSQL Complete After Syntax Error', () => {
+    const trino = new TrinoSQL();
+
+    const sql1 = `SELECT  FROM tb2;\nINSERT INTO `;
+    const sql2 = `SELECT  FROM tb3;\nCREATE TABLE `;
+    const sql3 = `SELECT FROM t1;\nSL`;
+
+    test('Syntax error but end with semi, should suggest tableName', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 13,
+        };
+        const suggestion = trino.getSuggestionAtCaretPosition(sql1, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(1);
+        expect(syntaxes[0].syntaxContextType).toBe(EntityContextType.TABLE);
+
+        // keyword
+        const keywords = suggestion?.keywords;
+        expect(keywords.length).toBe(0);
+    });
+
+    test('Syntax error but end with semi, should suggest tableNameCreate', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 14,
+        };
+        const suggestion = trino.getSuggestionAtCaretPosition(sql2, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(1);
+        expect(syntaxes[0].syntaxContextType).toBe(EntityContextType.TABLE_CREATE);
+
+        // keyword
+        const keywords = suggestion?.keywords;
+        expect(keywords).toMatchUnorderedArray(['IF', 'IF NOT EXISTS']);
+    });
+
+    test('Syntax error but end with semi, should suggest filter token', () => {
+        const pos: CaretPosition = {
+            lineNumber: 2,
+            column: 2,
+        };
+        const suggestion = trino.getSuggestionAtCaretPosition(sql3, pos);
+        expect(suggestion).not.toBeUndefined();
+
+        // syntax
+        const syntaxes = suggestion?.syntax;
+        expect(syntaxes.length).toBe(0);
+
+        // keyword
+        const filterKeywords = suggestion?.keywords?.filter(
+            (item) => item.startsWith('S') && /S(?=.*L)/.test(item)
+        );
+        expect(filterKeywords).toMatchUnorderedArray(['SELECT']);
+    });
+});


### PR DESCRIPTION
## 在错误语法的 SQL 后进行自动补全


### 现状举例

1. 前方 SQL 语法错误导致光标所在位置无法准确的提示 INSERT 等关键字：
``` sql
SELECT FROM tb1;
I|
```
 
![image](https://github.com/user-attachments/assets/c80ce6ae-67ec-410d-be84-e6591c7e3a71)


2. 错误语法后的 SELECT * FROM 被解析为多个 statement，无法进行准确的自动补全：
``` sql
SELECT FROM tb1;
SELECT * FROM |
```
![image](https://github.com/user-attachments/assets/5bf23a5c-4dbf-40e6-be5b-ceb3d38b4ef5)


### 预期举例

1. 有分号分隔时，以分号后一位作为左边界，右边界不变，将区间内的内容给到 antlr4-c3 进行解析。此时期望能够提示 INSERT 等关键字

``` sql
SELECT  FROM tb1;
I|
```

2. 没有分号分隔时，无法感知第一行的 sql 语句已经结束。此时无法准确的自动补全

``` sql
SELECT FROM tb1
I|
```


### 改动思路

提到的左边界和右边界可以参考 [dt-sql-parser #231](https://github.com/DTStack/dt-sql-parser/pull/231) 的描述。

通过分隔符进行切分（通常是 `;`），这里依旧保留现状寻找最小合适范围的策略，并在此策略上继续优化，借助两种方式进一步缩小解析范围。

1. 在已经获取到的合适范围中以光标为起点，向左查找 ; 的 tokenIndex，并以此为左边界；
2. 在已经获取到的合适范围中以光标为起点，向右查找 ; 的 tokenIndex，并以此为右边界；

> 通常在写 SQL 时，一般不会先写当前语句的 ;，所以右边界一般不会再次改变。如果左右没有查找到 ; 则不修改左右边界。


### 实现效果

![2024-09-27 15 40 13](https://github.com/user-attachments/assets/88be93c3-b16a-4306-81bb-167f28433fc9)
