### PR TITLE
fix: update isContainCaret judgment when caret position token is whit…

### DIFF
--- a/src/parser/common/basicSQL.ts
+++ b/src/parser/common/basicSQL.ts
@@ -83,6 +83,7 @@ export abstract class BasicSQL<
      */
     protected abstract createEntityCollector(
         input: string,
+        allTokens?: Token[],
         caretTokenIndex?: number
     ): EntityCollector;
 
@@ -378,7 +379,7 @@ export abstract class BasicSQL<
             ? findCaretTokenIndex(caretPosition, allTokens)
             : void 0;
 
-        const collectListener = this.createEntityCollector(input, caretTokenIndex);
+        const collectListener = this.createEntityCollector(input, allTokens, caretTokenIndex);
         // const parser = this.createParserWithCache(input);
 
         // parser.entityCollecting = true;

--- a/src/parser/common/entityCollector.ts
+++ b/src/parser/common/entityCollector.ts
@@ -149,10 +149,10 @@ export abstract class EntityCollector {
             const token = this._allTokens[i];
             if (token.channel !== Token.HIDDEN_CHANNEL) {
                 // If prev nonhidden token is ';', the current token does not belong to any statement.
-                return token.text === ';' ? +Infinity : token.tokenIndex;
+                return token.text === ';' ? Infinity : token.tokenIndex;
             }
         }
-        return +Infinity;
+        return Infinity;
     }
 
     protected pushStmt(ctx: ParserRuleContext, type: StmtContextType) {

--- a/src/parser/flink/index.ts
+++ b/src/parser/flink/index.ts
@@ -37,8 +37,8 @@ export class FlinkSQL extends BasicSQL<FlinkSqlLexer, ProgramContext, FlinkSqlPa
         return new FlinkSqlSplitListener();
     }
 
-    protected createEntityCollector(input: string, caretTokenIndex?: number) {
-        return new FlinkEntityCollector(input, caretTokenIndex);
+    protected createEntityCollector(input: string, allTokens?: Token[], caretTokenIndex?: number) {
+        return new FlinkEntityCollector(input, allTokens, caretTokenIndex);
     }
 
     protected processCandidates(

--- a/src/parser/hive/index.ts
+++ b/src/parser/hive/index.ts
@@ -38,8 +38,8 @@ export class HiveSQL extends BasicSQL<HiveSqlLexer, ProgramContext, HiveSqlParse
         return new HiveSqlSplitListener();
     }
 
-    protected createEntityCollector(input: string, caretTokenIndex?: number) {
-        return new HiveEntityCollector(input, caretTokenIndex);
+    protected createEntityCollector(input: string, allTokens?: Token[], caretTokenIndex?: number) {
+        return new HiveEntityCollector(input, allTokens, caretTokenIndex);
     }
 
     protected processCandidates(

--- a/src/parser/impala/index.ts
+++ b/src/parser/impala/index.ts
@@ -36,8 +36,8 @@ export class ImpalaSQL extends BasicSQL<ImpalaSqlLexer, ProgramContext, ImpalaSq
         return new ImpalaSqlSplitListener();
     }
 
-    protected createEntityCollector(input: string, caretTokenIndex?: number) {
-        return new ImpalaEntityCollector(input, caretTokenIndex);
+    protected createEntityCollector(input: string, allTokens?: Token[], caretTokenIndex?: number) {
+        return new ImpalaEntityCollector(input, allTokens, caretTokenIndex);
     }
 
     protected processCandidates(

--- a/src/parser/mysql/index.ts
+++ b/src/parser/mysql/index.ts
@@ -36,8 +36,8 @@ export class MySQL extends BasicSQL<MySqlLexer, ProgramContext, MySqlParser> {
         return new MysqlSplitListener();
     }
 
-    protected createEntityCollector(input: string, caretTokenIndex?: number) {
-        return new MySqlEntityCollector(input, caretTokenIndex);
+    protected createEntityCollector(input: string, allTokens?: Token[], caretTokenIndex?: number) {
+        return new MySqlEntityCollector(input, allTokens, caretTokenIndex);
     }
 
     protected processCandidates(

--- a/src/parser/postgresql/index.ts
+++ b/src/parser/postgresql/index.ts
@@ -41,8 +41,8 @@ export class PostgreSQL extends BasicSQL<PostgreSqlLexer, ProgramContext, Postgr
         return new PostgreSqlSplitListener();
     }
 
-    protected createEntityCollector(input: string, caretTokenIndex?: number) {
-        return new PostgreSqlEntityCollector(input, caretTokenIndex);
+    protected createEntityCollector(input: string, allTokens?: Token[], caretTokenIndex?: number) {
+        return new PostgreSqlEntityCollector(input, allTokens, caretTokenIndex);
     }
 
     protected processCandidates(

--- a/src/parser/spark/index.ts
+++ b/src/parser/spark/index.ts
@@ -36,8 +36,8 @@ export class SparkSQL extends BasicSQL<SparkSqlLexer, ProgramContext, SparkSqlPa
         return new SparkSqlSplitListener();
     }
 
-    protected createEntityCollector(input: string, caretTokenIndex?: number) {
-        return new SparkEntityCollector(input, caretTokenIndex);
+    protected createEntityCollector(input: string, allTokens?: Token[], caretTokenIndex?: number) {
+        return new SparkEntityCollector(input, allTokens, caretTokenIndex);
     }
 
     protected processCandidates(

--- a/src/parser/trino/index.ts
+++ b/src/parser/trino/index.ts
@@ -23,8 +23,8 @@ export class TrinoSQL extends BasicSQL<TrinoSqlLexer, ProgramContext, TrinoSqlPa
         return new TrinoSqlSplitListener();
     }
 
-    protected createEntityCollector(input: string, caretTokenIndex?: number) {
-        return new TrinoEntityCollector(input, caretTokenIndex);
+    protected createEntityCollector(input: string, allTokens?: Token[], caretTokenIndex?: number) {
+        return new TrinoEntityCollector(input, allTokens, caretTokenIndex);
     }
 
     protected preferredRules: Set<number> = new Set([

--- a/test/parser/flink/suggestion/fixtures/suggestionWithEntity.sql
+++ b/test/parser/flink/suggestion/fixtures/suggestionWithEntity.sql
@@ -9,3 +9,7 @@ INSERT INTO insert_tb PARTITION (country, state) SELECT col1, col2, country, sta
 CREATE TABLE IF NOT EXISTS derived_table WITH ('connector' = 'kafka')  AS SELECT  FROM origin_table;
 
 CREATE TABLE IF NOT EXISTS derived_table WITH ('connector' = 'kafka')  AS SELECT id,  FROM origin_table;
+
+SELECT id FROM tb WHERE 
+
+SELECT id FROM tb GROUP BY  ;  

--- a/test/parser/flink/suggestion/suggestionWithEntity.test.ts
+++ b/test/parser/flink/suggestion/suggestionWithEntity.test.ts
@@ -157,4 +157,24 @@ describe('Flink SQL Syntax Suggestion with collect entity', () => {
         expect(entities[1].entityContextType).toBe(EntityContextType.TABLE);
         expect(entities[1].belongStmt.isContainCaret).toBeTruthy();
     });
+
+    test('isContainCaret should be truthy if caret position is whitespace at the end of statement', () => {
+        const pos: CaretPosition = {
+            lineNumber: 13,
+            column: 25,
+        };
+        const sql = commentOtherLine(syntaxSql, pos.lineNumber);
+        const entities = flink.getAllEntities(sql, pos);
+        expect(entities[0].belongStmt.isContainCaret).toBeTruthy();
+    });
+
+    test('isContainCaret should be falsy if caret position is whitespace after semicolon', () => {
+        const pos: CaretPosition = {
+            lineNumber: 15,
+            column: 32,
+        };
+        const sql = commentOtherLine(syntaxSql, pos.lineNumber);
+        const entities = flink.getAllEntities(sql, pos);
+        expect(entities[0].belongStmt.isContainCaret).toBeFalsy();
+    });
 });

--- a/test/parser/hive/suggestion/fixtures/suggestionWithEntity.sql
+++ b/test/parser/hive/suggestion/fixtures/suggestionWithEntity.sql
@@ -21,3 +21,7 @@ INSERT INTO insert_tb PARTITION (country, state) SELECT col1, col2, country, sta
 CREATE TABLE IF NOT EXISTS derived_table AS SELECT  FROM origin_table
 
 CREATE TABLE IF NOT EXISTS derived_table AS SELECT id,  FROM origin_table
+
+SELECT id FROM tb WHERE 
+
+SELECT id FROM tb GROUP BY  ;  

--- a/test/parser/hive/suggestion/suggestionWithEntity.test.ts
+++ b/test/parser/hive/suggestion/suggestionWithEntity.test.ts
@@ -118,12 +118,12 @@ describe('Hive SQL Syntax Suggestion with collect entity', () => {
         expect(entities.length).toBe(2);
         expect(entities[0].text).toBe('a');
         expect(entities[0].entityContextType).toBe(EntityContextType.TABLE);
-        expect(entities[0].belongStmt.isContainCaret).toBeFalsy();
+        expect(entities[0].belongStmt.isContainCaret).toBeTruthy();
         expect(entities[0].belongStmt.rootStmt.isContainCaret).toBeTruthy();
 
         expect(entities[1].text).toBe('b');
         expect(entities[1].entityContextType).toBe(EntityContextType.TABLE);
-        expect(entities[1].belongStmt.isContainCaret).toBeFalsy();
+        expect(entities[1].belongStmt.isContainCaret).toBeTruthy();
         expect(entities[1].belongStmt.rootStmt.isContainCaret).toBeTruthy();
     });
 
@@ -145,12 +145,12 @@ describe('Hive SQL Syntax Suggestion with collect entity', () => {
         expect(entities.length).toBe(2);
         expect(entities[0].text).toBe('a');
         expect(entities[0].entityContextType).toBe(EntityContextType.TABLE);
-        expect(entities[0].belongStmt.isContainCaret).toBeFalsy();
+        expect(entities[0].belongStmt.isContainCaret).toBeTruthy();
         expect(entities[0].belongStmt.rootStmt.isContainCaret).toBeTruthy();
 
         expect(entities[1].text).toBe('b');
         expect(entities[1].entityContextType).toBe(EntityContextType.TABLE);
-        expect(entities[1].belongStmt.isContainCaret).toBeFalsy();
+        expect(entities[1].belongStmt.isContainCaret).toBeTruthy();
         expect(entities[1].belongStmt.rootStmt.isContainCaret).toBeTruthy();
     });
 
@@ -172,12 +172,12 @@ describe('Hive SQL Syntax Suggestion with collect entity', () => {
         expect(entities.length).toBe(2);
         expect(entities[0].text).toBe('page_view_stg');
         expect(entities[0].entityContextType).toBe(EntityContextType.TABLE);
-        expect(entities[0].belongStmt.isContainCaret).toBeFalsy();
+        expect(entities[0].belongStmt.isContainCaret).toBeTruthy();
         expect(entities[0].belongStmt.rootStmt.isContainCaret).toBeTruthy();
 
         expect(entities[1].text).toBe('page_view');
         expect(entities[1].entityContextType).toBe(EntityContextType.TABLE);
-        expect(entities[1].belongStmt.isContainCaret).toBeFalsy();
+        expect(entities[1].belongStmt.isContainCaret).toBeTruthy();
         expect(entities[1].belongStmt.rootStmt.isContainCaret).toBeTruthy();
     });
 
@@ -199,12 +199,12 @@ describe('Hive SQL Syntax Suggestion with collect entity', () => {
         expect(entities.length).toBe(2);
         expect(entities[0].text).toBe('page_view_stg');
         expect(entities[0].entityContextType).toBe(EntityContextType.TABLE);
-        expect(entities[0].belongStmt.isContainCaret).toBeFalsy();
+        expect(entities[0].belongStmt.isContainCaret).toBeTruthy();
         expect(entities[0].belongStmt.rootStmt.isContainCaret).toBeTruthy();
 
         expect(entities[1].text).toBe('page_view');
         expect(entities[1].entityContextType).toBe(EntityContextType.TABLE);
-        expect(entities[1].belongStmt.isContainCaret).toBeFalsy();
+        expect(entities[1].belongStmt.isContainCaret).toBeTruthy();
         expect(entities[1].belongStmt.rootStmt.isContainCaret).toBeTruthy();
     });
 
@@ -306,5 +306,25 @@ describe('Hive SQL Syntax Suggestion with collect entity', () => {
         expect(entities[1].text).toBe('origin_table');
         expect(entities[1].entityContextType).toBe(EntityContextType.TABLE);
         expect(entities[1].belongStmt.isContainCaret).toBeTruthy();
+    });
+
+    test('isContainCaret should be truthy if caret position is whitespace at the end of statement', () => {
+        const pos: CaretPosition = {
+            lineNumber: 25,
+            column: 25,
+        };
+        const sql = commentOtherLine(syntaxSql, pos.lineNumber);
+        const entities = hive.getAllEntities(sql, pos);
+        expect(entities[0].belongStmt.isContainCaret).toBeTruthy();
+    });
+
+    test('isContainCaret should be falsy if caret position is whitespace after semicolon', () => {
+        const pos: CaretPosition = {
+            lineNumber: 27,
+            column: 32,
+        };
+        const sql = commentOtherLine(syntaxSql, pos.lineNumber);
+        const entities = hive.getAllEntities(sql, pos);
+        expect(entities[0].belongStmt.isContainCaret).toBeFalsy();
     });
 });

--- a/test/parser/impala/suggestion/fixtures/suggestionWithEntity.sql
+++ b/test/parser/impala/suggestion/fixtures/suggestionWithEntity.sql
@@ -9,3 +9,7 @@ INSERT INTO insert_tb SELECT id,  FROM from_tb;
 CREATE TABLE sorted_census_data AS SELECT  FROM unsorted_census_data;
 
 CREATE TABLE sorted_census_data AS SELECT id,  FROM unsorted_census_data;
+
+SELECT id FROM tb WHERE 
+
+SELECT id FROM tb GROUP BY  ;  

--- a/test/parser/impala/suggestion/suggestionWithEntity.test.ts
+++ b/test/parser/impala/suggestion/suggestionWithEntity.test.ts
@@ -155,4 +155,24 @@ describe('Impala SQL Syntax Suggestion with collect entity', () => {
         expect(entities[1].entityContextType).toBe(EntityContextType.TABLE);
         expect(entities[1].belongStmt.isContainCaret).toBeTruthy();
     });
+
+    test('isContainCaret should be truthy if caret position is whitespace at the end of statement', () => {
+        const pos: CaretPosition = {
+            lineNumber: 13,
+            column: 25,
+        };
+        const sql = commentOtherLine(syntaxSql, pos.lineNumber);
+        const entities = impala.getAllEntities(sql, pos);
+        expect(entities[0].belongStmt.isContainCaret).toBeTruthy();
+    });
+
+    test('isContainCaret should be falsy if caret position is whitespace after semicolon', () => {
+        const pos: CaretPosition = {
+            lineNumber: 15,
+            column: 32,
+        };
+        const sql = commentOtherLine(syntaxSql, pos.lineNumber);
+        const entities = impala.getAllEntities(sql, pos);
+        expect(entities[0].belongStmt.isContainCaret).toBeFalsy();
+    });
 });

--- a/test/parser/mysql/suggestion/fixtures/suggestionWithEntity.sql
+++ b/test/parser/mysql/suggestion/fixtures/suggestionWithEntity.sql
@@ -9,3 +9,7 @@ INSERT INTO insert_tb SELECT id, age,  FROM from_tb;
 CREATE TABLE sorted_census_data AS SELECT  FROM unsorted_census_data;
 
 CREATE TABLE sorted_census_data AS SELECT id, age,  FROM unsorted_census_data;
+
+SELECT id FROM tb WHERE 
+
+SELECT id FROM tb GROUP BY  ;  

--- a/test/parser/mysql/suggestion/suggestionWithEntity.test.ts
+++ b/test/parser/mysql/suggestion/suggestionWithEntity.test.ts
@@ -153,4 +153,24 @@ describe('MySQL Syntax Suggestion with collect entity', () => {
         expect(entities[1].entityContextType).toBe(EntityContextType.TABLE);
         expect(entities[1].belongStmt.isContainCaret).toBeTruthy();
     });
+
+    test('isContainCaret should be truthy if caret position is whitespace at the end of statement', () => {
+        const pos: CaretPosition = {
+            lineNumber: 13,
+            column: 25,
+        };
+        const sql = commentOtherLine(syntaxSql, pos.lineNumber);
+        const entities = mysql.getAllEntities(sql, pos);
+        expect(entities[0].belongStmt.isContainCaret).toBeTruthy();
+    });
+
+    test('isContainCaret should be falsy if caret position is whitespace after semicolon', () => {
+        const pos: CaretPosition = {
+            lineNumber: 15,
+            column: 32,
+        };
+        const sql = commentOtherLine(syntaxSql, pos.lineNumber);
+        const entities = mysql.getAllEntities(sql, pos);
+        expect(entities[0].belongStmt.isContainCaret).toBeFalsy();
+    });
 });

--- a/test/parser/postgresql/suggestion/fixtures/suggestionWithEntity.sql
+++ b/test/parser/postgresql/suggestion/fixtures/suggestionWithEntity.sql
@@ -11,3 +11,7 @@ CREATE TABLE sorted_census_data AS SELECT  FROM unsorted_census_data;
 CREATE TABLE sorted_census_data AS SELECT id, age,  FROM unsorted_census_data;
 
 ALTER TABLE my_table DROP a_column;
+
+SELECT id FROM tb WHERE 
+
+SELECT id FROM tb GROUP BY  ;  

--- a/test/parser/postgresql/suggestion/suggestionWithEntity.test.ts
+++ b/test/parser/postgresql/suggestion/suggestionWithEntity.test.ts
@@ -174,4 +174,24 @@ describe('PostgreSql Syntax Suggestion with collect entity', () => {
         expect(entities[0].entityContextType).toBe(EntityContextType.TABLE);
         expect(entities[0].belongStmt?.isContainCaret).toBeTruthy();
     });
+
+    test('isContainCaret should be truthy if caret position is whitespace at the end of statement', () => {
+        const pos: CaretPosition = {
+            lineNumber: 15,
+            column: 25,
+        };
+        const sql = commentOtherLine(syntaxSql, pos.lineNumber);
+        const entities = postgre.getAllEntities(sql, pos);
+        expect(entities[0].belongStmt.isContainCaret).toBeTruthy();
+    });
+
+    test('isContainCaret should be falsy if caret position is whitespace after semicolon', () => {
+        const pos: CaretPosition = {
+            lineNumber: 17,
+            column: 32,
+        };
+        const sql = commentOtherLine(syntaxSql, pos.lineNumber);
+        const entities = postgre.getAllEntities(sql, pos);
+        expect(entities[0].belongStmt.isContainCaret).toBeFalsy();
+    });
 });

--- a/test/parser/spark/suggestion/fixtures/suggestionWithEntity.sql
+++ b/test/parser/spark/suggestion/fixtures/suggestionWithEntity.sql
@@ -9,3 +9,7 @@ INSERT INTO insert_tb SELECT id, age,  FROM from_tb;
 CREATE TABLE sorted_census_data AS SELECT  FROM unsorted_census_data;
 
 CREATE TABLE sorted_census_data AS SELECT id, age,  FROM unsorted_census_data;
+
+SELECT id FROM tb WHERE 
+
+SELECT id FROM tb GROUP BY  ;  

--- a/test/parser/spark/suggestion/suggestionWithEntity.test.ts
+++ b/test/parser/spark/suggestion/suggestionWithEntity.test.ts
@@ -153,4 +153,24 @@ describe('PostgreSql Syntax Suggestion with collect entity', () => {
         expect(entities[1].entityContextType).toBe(EntityContextType.TABLE);
         expect(entities[1].belongStmt.isContainCaret).toBeTruthy();
     });
+
+    test('isContainCaret should be truthy if caret position is whitespace at the end of statement', () => {
+        const pos: CaretPosition = {
+            lineNumber: 13,
+            column: 25,
+        };
+        const sql = commentOtherLine(syntaxSql, pos.lineNumber);
+        const entities = spark.getAllEntities(sql, pos);
+        expect(entities[0].belongStmt.isContainCaret).toBeTruthy();
+    });
+
+    test('isContainCaret should be falsy if caret position is whitespace after semicolon', () => {
+        const pos: CaretPosition = {
+            lineNumber: 15,
+            column: 32,
+        };
+        const sql = commentOtherLine(syntaxSql, pos.lineNumber);
+        const entities = spark.getAllEntities(sql, pos);
+        expect(entities[0].belongStmt.isContainCaret).toBeFalsy();
+    });
 });

--- a/test/parser/trino/suggestion/fixtures/suggestionWithEntity.sql
+++ b/test/parser/trino/suggestion/fixtures/suggestionWithEntity.sql
@@ -9,3 +9,7 @@ INSERT INTO insert_tb SELECT id, age,  FROM from_tb;
 CREATE TABLE sorted_census_data AS SELECT  FROM unsorted_census_data;
 
 CREATE TABLE sorted_census_data AS SELECT id, age,  FROM unsorted_census_data;
+
+SELECT id FROM tb WHERE 
+
+SELECT id FROM tb GROUP BY  ;  

--- a/test/parser/trino/suggestion/suggestionWithEntity.test.ts
+++ b/test/parser/trino/suggestion/suggestionWithEntity.test.ts
@@ -156,4 +156,24 @@ describe('PostgreSql Syntax Suggestion with collect entity', () => {
         expect(entities[1].entityContextType).toBe(EntityContextType.TABLE);
         expect(entities[1].belongStmt.isContainCaret).toBeTruthy();
     });
+
+    test('isContainCaret should be truthy if caret position is whitespace at the end of statement', () => {
+        const pos: CaretPosition = {
+            lineNumber: 13,
+            column: 25,
+        };
+        const sql = commentOtherLine(syntaxSql, pos.lineNumber);
+        const entities = trino.getAllEntities(sql, pos);
+        expect(entities[0].belongStmt.isContainCaret).toBeTruthy();
+    });
+
+    test('isContainCaret should be falsy if caret position is whitespace after semicolon', () => {
+        const pos: CaretPosition = {
+            lineNumber: 15,
+            column: 32,
+        };
+        const sql = commentOtherLine(syntaxSql, pos.lineNumber);
+        const entities = trino.getAllEntities(sql, pos);
+        expect(entities[0].belongStmt.isContainCaret).toBeFalsy();
+    });
 });


### PR DESCRIPTION
修复 #288 

问题产生原因：

空格等`hidden-channel`类型的 token 会被 antlr4 解析时忽略掉，导致判断语句结束位置时， `ctx.stop` 关联的 token 不会是空格。

<img width="569" alt="image" src="https://github.com/user-attachments/assets/bd0babfa-9e12-4bf7-b196-d4cbf4b1df12" />


解决方法：
从当前 token 位置往前找到第一个非`hidden-channel` token 作为判断依据, 同时需要排除掉分号情况。例如：
```sql
# tb实体中isContainCaret = true
SELECT id FROM tb WHERE  <cursor_pos>

# tb实体中isContainCaret = false
SELECT id FROM tb WHERE   ; <cursor_pos>

```
