### PR TITLE
fix(ci): use project.reject when just check mode

### DIFF
--- a/scripts/antlr4.js
+++ b/scripts/antlr4.js
@@ -61,7 +61,7 @@ function compile(language) {
                     return newHash !== prevHash;
                 });
 
-                if (changedFiles.length > 0) {
+                if (changedFiles.length > 0 && argv.check) {
                     return reject(`${language} not run antlr4`);
                 }
                 resolve();


### PR DESCRIPTION
#403 

之前为了在 ci 中做 g4 文件的判断，增加了报错，导致本地跑 antlr4 也会报错。更改当前代码，只有在 check 模式下报错