### PR TITLE
feat: #410 optimize processCandidates tokenIndexOffset

### DIFF
--- a/src/parser/common/basicSQL.ts
+++ b/src/parser/common/basicSQL.ts
@@ -73,15 +73,13 @@ export abstract class BasicSQL<
     /**
      * Convert candidates to suggestions
      * @param candidates candidate list
-     * @param allTokens all tokens from input
+     * @param allTokens slice all tokens from input by tokenIndexOffset
      * @param caretTokenIndex tokenIndex of caretPosition
-     * @param tokenIndexOffset offset of the tokenIndex in the candidates compared to the tokenIndex in allTokens
      */
     protected abstract processCandidates(
         candidates: CandidatesCollection,
         allTokens: Token[],
-        caretTokenIndex: number,
-        tokenIndexOffset: number
+        caretTokenIndex: number
     ): Suggestions<Token>;
 
     /**
@@ -539,13 +537,7 @@ export abstract class BasicSQL<
         core.preferredRules = this.preferredRules;
 
         const candidates = core.collectCandidates(caretTokenIndex, parseTree);
-        const originalSuggestions = this.processCandidates(
-            candidates,
-            allTokens,
-            caretTokenIndex,
-            0
-            // tokenIndexOffset
-        );
+        const originalSuggestions = this.processCandidates(candidates, allTokens, caretTokenIndex);
 
         const syntaxSuggestions: SyntaxSuggestion<WordRange>[] = originalSuggestions.syntax.map(
             (syntaxCtx) => {

--- a/src/parser/flink/index.ts
+++ b/src/parser/flink/index.ts
@@ -68,19 +68,14 @@ export class FlinkSQL extends BasicSQL<FlinkSqlLexer, ProgramContext, FlinkSqlPa
     protected processCandidates(
         candidates: CandidatesCollection,
         allTokens: Token[],
-        caretTokenIndex: number,
-        tokenIndexOffset: number
+        caretTokenIndex: number
     ): Suggestions<Token> {
         const originalSyntaxSuggestions: SyntaxSuggestion<Token>[] = [];
         const keywords: string[] = [];
 
         for (let candidate of candidates.rules) {
             const [ruleType, candidateRule] = candidate;
-            const startTokenIndex = candidateRule.startTokenIndex + tokenIndexOffset;
-            const tokenRanges = allTokens.slice(
-                startTokenIndex,
-                caretTokenIndex + tokenIndexOffset + 1
-            );
+            const tokenRanges = allTokens.slice(candidateRule.startTokenIndex, caretTokenIndex + 1);
 
             let syntaxContextType: EntityContextType | StmtContextType | undefined = void 0;
             switch (ruleType) {

--- a/src/parser/hive/index.ts
+++ b/src/parser/hive/index.ts
@@ -69,18 +69,13 @@ export class HiveSQL extends BasicSQL<HiveSqlLexer, ProgramContext, HiveSqlParse
     protected processCandidates(
         candidates: CandidatesCollection,
         allTokens: Token[],
-        caretTokenIndex: number,
-        tokenIndexOffset: number
+        caretTokenIndex: number
     ): Suggestions<Token> {
         const originalSyntaxSuggestions: SyntaxSuggestion<Token>[] = [];
         const keywords: string[] = [];
         for (let candidate of candidates.rules) {
             const [ruleType, candidateRule] = candidate;
-            const startTokenIndex = candidateRule.startTokenIndex + tokenIndexOffset;
-            const tokenRanges = allTokens.slice(
-                startTokenIndex,
-                caretTokenIndex + tokenIndexOffset + 1
-            );
+            const tokenRanges = allTokens.slice(candidateRule.startTokenIndex, caretTokenIndex + 1);
 
             let syntaxContextType: EntityContextType | StmtContextType | undefined = void 0;
             switch (ruleType) {

--- a/src/parser/impala/index.ts
+++ b/src/parser/impala/index.ts
@@ -67,18 +67,13 @@ export class ImpalaSQL extends BasicSQL<ImpalaSqlLexer, ProgramContext, ImpalaSq
     protected processCandidates(
         candidates: CandidatesCollection,
         allTokens: Token[],
-        caretTokenIndex: number,
-        tokenIndexOffset: number
+        caretTokenIndex: number
     ): Suggestions<Token> {
         const originalSyntaxSuggestions: SyntaxSuggestion<Token>[] = [];
         const keywords: string[] = [];
         for (let candidate of candidates.rules) {
             const [ruleType, candidateRule] = candidate;
-            const startTokenIndex = candidateRule.startTokenIndex + tokenIndexOffset;
-            const tokenRanges = allTokens.slice(
-                startTokenIndex,
-                caretTokenIndex + tokenIndexOffset + 1
-            );
+            const tokenRanges = allTokens.slice(candidateRule.startTokenIndex, caretTokenIndex + 1);
 
             let syntaxContextType: EntityContextType | StmtContextType | undefined = void 0;
             switch (ruleType) {

--- a/src/parser/mysql/index.ts
+++ b/src/parser/mysql/index.ts
@@ -66,19 +66,14 @@ export class MySQL extends BasicSQL<MySqlLexer, ProgramContext, MySqlParser> {
     protected processCandidates(
         candidates: CandidatesCollection,
         allTokens: Token[],
-        caretTokenIndex: number,
-        tokenIndexOffset: number
+        caretTokenIndex: number
     ): Suggestions<Token> {
         const originalSyntaxSuggestions: SyntaxSuggestion<Token>[] = [];
         const keywords: string[] = [];
 
         for (const candidate of candidates.rules) {
             const [ruleType, candidateRule] = candidate;
-            const startTokenIndex = candidateRule.startTokenIndex + tokenIndexOffset;
-            const tokenRanges = allTokens.slice(
-                startTokenIndex,
-                caretTokenIndex + tokenIndexOffset + 1
-            );
+            const tokenRanges = allTokens.slice(candidateRule.startTokenIndex, caretTokenIndex + 1);
 
             let syntaxContextType: EntityContextType | StmtContextType | undefined = void 0;
             switch (ruleType) {

--- a/src/parser/postgresql/index.ts
+++ b/src/parser/postgresql/index.ts
@@ -72,18 +72,13 @@ export class PostgreSQL extends BasicSQL<PostgreSqlLexer, ProgramContext, Postgr
     protected processCandidates(
         candidates: CandidatesCollection,
         allTokens: Token[],
-        caretTokenIndex: number,
-        tokenIndexOffset: number
+        caretTokenIndex: number
     ): Suggestions<Token> {
         const originalSyntaxSuggestions: SyntaxSuggestion<Token>[] = [];
         const keywords: string[] = [];
         for (let candidate of candidates.rules) {
             const [ruleType, candidateRule] = candidate;
-            const startTokenIndex = candidateRule.startTokenIndex + tokenIndexOffset;
-            const tokenRanges = allTokens.slice(
-                startTokenIndex,
-                caretTokenIndex + tokenIndexOffset + 1
-            );
+            const tokenRanges = allTokens.slice(candidateRule.startTokenIndex, caretTokenIndex + 1);
 
             let syntaxContextType: EntityContextType | StmtContextType | undefined = void 0;
             switch (ruleType) {

--- a/src/parser/spark/index.ts
+++ b/src/parser/spark/index.ts
@@ -67,19 +67,14 @@ export class SparkSQL extends BasicSQL<SparkSqlLexer, ProgramContext, SparkSqlPa
     protected processCandidates(
         candidates: CandidatesCollection,
         allTokens: Token[],
-        caretTokenIndex: number,
-        tokenIndexOffset: number
+        caretTokenIndex: number
     ): Suggestions<Token> {
         const originalSyntaxSuggestions: SyntaxSuggestion<Token>[] = [];
         const keywords: string[] = [];
 
         for (const candidate of candidates.rules) {
             const [ruleType, candidateRule] = candidate;
-            const startTokenIndex = candidateRule.startTokenIndex + tokenIndexOffset;
-            const tokenRanges = allTokens.slice(
-                startTokenIndex,
-                caretTokenIndex + tokenIndexOffset + 1
-            );
+            const tokenRanges = allTokens.slice(candidateRule.startTokenIndex, caretTokenIndex + 1);
 
             let syntaxContextType: EntityContextType | StmtContextType | undefined = void 0;
             switch (ruleType) {

--- a/src/parser/trino/index.ts
+++ b/src/parser/trino/index.ts
@@ -69,19 +69,14 @@ export class TrinoSQL extends BasicSQL<TrinoSqlLexer, ProgramContext, TrinoSqlPa
     protected processCandidates(
         candidates: CandidatesCollection,
         allTokens: Token[],
-        caretTokenIndex: number,
-        tokenIndexOffset: number
+        caretTokenIndex: number
     ): Suggestions<Token> {
         const originalSyntaxSuggestions: SyntaxSuggestion<Token>[] = [];
         const keywords: string[] = [];
 
         for (let candidate of candidates.rules) {
             const [ruleType, candidateRule] = candidate;
-            const startTokenIndex = candidateRule.startTokenIndex + tokenIndexOffset;
-            const tokenRanges = allTokens.slice(
-                startTokenIndex,
-                caretTokenIndex + tokenIndexOffset + 1
-            );
+            const tokenRanges = allTokens.slice(candidateRule.startTokenIndex, caretTokenIndex + 1);
 
             let syntaxContextType: EntityContextType | StmtContextType | undefined = void 0;
             switch (ruleType) {

--- a/test/parser/flink/suggestion/multipleStatement.test.ts
+++ b/test/parser/flink/suggestion/multipleStatement.test.ts
@@ -36,7 +36,25 @@ describe('FlinkSQL Multiple Statements Syntax Suggestion', () => {
         );
 
         expect(suggestion).not.toBeUndefined();
-        expect(suggestion?.wordRanges.map((token) => token.text)).toEqual(['db', '.']);
+        expect(suggestion?.wordRanges?.length).toBe(2);
+        expect(suggestion?.wordRanges).toEqual([
+            {
+                text: 'db',
+                line: 16,
+                startIndex: 306,
+                endIndex: 307,
+                startColumn: 14,
+                endColumn: 16,
+            },
+            {
+                text: '.',
+                line: 16,
+                startIndex: 308,
+                endIndex: 308,
+                startColumn: 16,
+                endColumn: 17,
+            },
+        ]);
     });
 
     test('Insert into table ', () => {

--- a/test/parser/flink/suggestion/syntaxSuggestion.test.ts
+++ b/test/parser/flink/suggestion/syntaxSuggestion.test.ts
@@ -32,7 +32,17 @@ describe('Flink SQL Syntax Suggestion', () => {
         );
 
         expect(suggestion).not.toBeUndefined();
-        expect(suggestion?.wordRanges.map((token) => token.text)).toEqual(['cat']);
+        expect(suggestion?.wordRanges?.length).toBe(1);
+        expect(suggestion?.wordRanges).toEqual([
+            {
+                text: 'cat',
+                line: 1,
+                startIndex: 13,
+                endIndex: 15,
+                startColumn: 14,
+                endColumn: 17,
+            },
+        ]);
     });
 
     test('Select table', () => {

--- a/test/parser/hive/suggestion/multipleStatement.test.ts
+++ b/test/parser/hive/suggestion/multipleStatement.test.ts
@@ -36,7 +36,25 @@ describe('HiveSQL Multiple Statements Syntax Suggestion', () => {
         );
 
         expect(suggestion).not.toBeUndefined();
-        expect(suggestion?.wordRanges.map((token) => token.text)).toEqual(['db', '.']);
+        expect(suggestion?.wordRanges?.length).toBe(2);
+        expect(suggestion?.wordRanges).toEqual([
+            {
+                text: 'db',
+                line: 9,
+                startIndex: 272,
+                endIndex: 273,
+                startColumn: 14,
+                endColumn: 16,
+            },
+            {
+                text: '.',
+                line: 9,
+                startIndex: 274,
+                endIndex: 274,
+                startColumn: 16,
+                endColumn: 17,
+            },
+        ]);
     });
 
     test('Insert into table ', () => {

--- a/test/parser/hive/suggestion/syntaxSuggestion.test.ts
+++ b/test/parser/hive/suggestion/syntaxSuggestion.test.ts
@@ -32,7 +32,33 @@ describe('Hive SQL Syntax Suggestion', () => {
         );
 
         expect(suggestion).not.toBeUndefined();
-        expect(suggestion?.wordRanges.map((token) => token.text)).toEqual(['db', '.', 'tb']);
+        expect(suggestion?.wordRanges?.length).toBe(3);
+        expect(suggestion?.wordRanges).toEqual([
+            {
+                text: 'db',
+                line: 1,
+                startIndex: 12,
+                endIndex: 13,
+                startColumn: 13,
+                endColumn: 15,
+            },
+            {
+                text: '.',
+                line: 1,
+                startIndex: 14,
+                endIndex: 14,
+                startColumn: 15,
+                endColumn: 16,
+            },
+            {
+                text: 'tb',
+                line: 1,
+                startIndex: 15,
+                endIndex: 16,
+                startColumn: 16,
+                endColumn: 18,
+            },
+        ]);
     });
 
     test('Select table ', () => {

--- a/test/parser/impala/suggestion/multipleStatement.test.ts
+++ b/test/parser/impala/suggestion/multipleStatement.test.ts
@@ -36,7 +36,25 @@ describe('ImpalaSQL Multiple Statements Syntax Suggestion', () => {
         );
 
         expect(suggestion).not.toBeUndefined();
-        expect(suggestion?.wordRanges.map((token) => token.text)).toEqual(['db', '.']);
+        expect(suggestion?.wordRanges?.length).toBe(2);
+        expect(suggestion?.wordRanges).toEqual([
+            {
+                text: 'db',
+                line: 9,
+                startIndex: 203,
+                endIndex: 204,
+                startColumn: 14,
+                endColumn: 16,
+            },
+            {
+                text: '.',
+                line: 9,
+                startIndex: 205,
+                endIndex: 205,
+                startColumn: 16,
+                endColumn: 17,
+            },
+        ]);
     });
 
     test('Insert into table ', () => {

--- a/test/parser/impala/suggestion/syntaxSuggestion.test.ts
+++ b/test/parser/impala/suggestion/syntaxSuggestion.test.ts
@@ -26,7 +26,33 @@ describe('Impala SQL Syntax Suggestion', () => {
         );
 
         expect(suggestion).not.toBeUndefined();
-        expect(suggestion?.wordRanges.map((token) => token.text)).toEqual(['cat', '.', 'a']);
+        expect(suggestion?.wordRanges?.length).toBe(3);
+        expect(suggestion?.wordRanges).toEqual([
+            {
+                text: 'cat',
+                line: 1,
+                startIndex: 14,
+                endIndex: 16,
+                startColumn: 15,
+                endColumn: 18,
+            },
+            {
+                text: '.',
+                line: 1,
+                startIndex: 17,
+                endIndex: 17,
+                startColumn: 18,
+                endColumn: 19,
+            },
+            {
+                text: 'a',
+                line: 1,
+                startIndex: 18,
+                endIndex: 18,
+                startColumn: 19,
+                endColumn: 20,
+            },
+        ]);
     });
 
     test('Function call', () => {

--- a/test/parser/mysql/suggestion/multipleStatement.test.ts
+++ b/test/parser/mysql/suggestion/multipleStatement.test.ts
@@ -36,7 +36,25 @@ describe('MySQL Multiple Statements Syntax Suggestion', () => {
         );
 
         expect(suggestion).not.toBeUndefined();
-        expect(suggestion?.wordRanges.map((token) => token.text)).toEqual(['db', '.']);
+        expect(suggestion?.wordRanges?.length).toBe(2);
+        expect(suggestion?.wordRanges).toEqual([
+            {
+                text: 'db',
+                line: 9,
+                startIndex: 306,
+                endIndex: 307,
+                startColumn: 14,
+                endColumn: 16,
+            },
+            {
+                text: '.',
+                line: 9,
+                startIndex: 308,
+                endIndex: 308,
+                startColumn: 16,
+                endColumn: 17,
+            },
+        ]);
     });
 
     test('Insert into table ', () => {

--- a/test/parser/mysql/suggestion/syntaxSuggestion.test.ts
+++ b/test/parser/mysql/suggestion/syntaxSuggestion.test.ts
@@ -30,7 +30,33 @@ describe('MySQL Syntax Suggestion', () => {
         );
 
         expect(suggestion).not.toBeUndefined();
-        expect(suggestion?.wordRanges.map((token) => token.text)).toEqual(['db', '.', 'tb']);
+        expect(suggestion?.wordRanges?.length).toBe(3);
+        expect(suggestion?.wordRanges).toEqual([
+            {
+                text: 'db',
+                line: 1,
+                startIndex: 12,
+                endIndex: 13,
+                startColumn: 13,
+                endColumn: 15,
+            },
+            {
+                text: '.',
+                line: 1,
+                startIndex: 14,
+                endIndex: 14,
+                startColumn: 15,
+                endColumn: 16,
+            },
+            {
+                text: 'tb',
+                line: 1,
+                startIndex: 15,
+                endIndex: 16,
+                startColumn: 16,
+                endColumn: 18,
+            },
+        ]);
     });
 
     test('Select table ', () => {

--- a/test/parser/postgresql/suggestion/multipleStatement.test.ts
+++ b/test/parser/postgresql/suggestion/multipleStatement.test.ts
@@ -69,6 +69,24 @@ describe('PgSQL Multiple Statements Syntax Suggestion', () => {
         );
 
         expect(suggestion).not.toBeUndefined();
-        expect(suggestion?.wordRanges.map((token) => token.text)).toEqual(['db', '.']);
+        expect(suggestion?.wordRanges?.length).toBe(2);
+        expect(suggestion?.wordRanges).toEqual([
+            {
+                text: 'db',
+                line: 21,
+                startIndex: 682,
+                endIndex: 683,
+                startColumn: 62,
+                endColumn: 64,
+            },
+            {
+                text: '.',
+                line: 21,
+                startIndex: 684,
+                endIndex: 684,
+                startColumn: 64,
+                endColumn: 65,
+            },
+        ]);
     });
 });

--- a/test/parser/postgresql/suggestion/suggestionWithEntity.test.ts
+++ b/test/parser/postgresql/suggestion/suggestionWithEntity.test.ts
@@ -166,7 +166,17 @@ describe('PostgreSql Syntax Suggestion with collect entity', () => {
             (syn) => syn.syntaxContextType === EntityContextType.COLUMN
         );
         expect(suggestion).not.toBeUndefined();
-        expect(suggestion?.wordRanges.map((token) => token.text)).toEqual(['a_column']);
+        expect(suggestion?.wordRanges?.length).toBe(1);
+        expect(suggestion?.wordRanges).toEqual([
+            {
+                text: 'a_column',
+                line: 13,
+                startIndex: 399,
+                endIndex: 406,
+                startColumn: 27,
+                endColumn: 35,
+            },
+        ]);
 
         const entities = postgre.getAllEntities(sql, pos);
         expect(entities.length).toBe(1);

--- a/test/parser/postgresql/suggestion/syntaxSuggestion.test.ts
+++ b/test/parser/postgresql/suggestion/syntaxSuggestion.test.ts
@@ -32,7 +32,33 @@ describe('Postgre SQL Syntax Suggestion', () => {
         );
 
         expect(suggestion).not.toBeUndefined();
-        expect(suggestion?.wordRanges.map((token) => token.text)).toEqual(['db', '.', 'tb']);
+        expect(suggestion?.wordRanges?.length).toBe(3);
+        expect(suggestion?.wordRanges).toEqual([
+            {
+                text: 'db',
+                line: 3,
+                startIndex: 88,
+                endIndex: 89,
+                startColumn: 13,
+                endColumn: 15,
+            },
+            {
+                text: '.',
+                line: 3,
+                startIndex: 90,
+                endIndex: 90,
+                startColumn: 15,
+                endColumn: 16,
+            },
+            {
+                text: 'tb',
+                line: 3,
+                startIndex: 91,
+                endIndex: 92,
+                startColumn: 16,
+                endColumn: 18,
+            },
+        ]);
     });
 
     test('Alter table ', () => {

--- a/test/parser/spark/suggestion/multipleStatement.test.ts
+++ b/test/parser/spark/suggestion/multipleStatement.test.ts
@@ -36,7 +36,25 @@ describe('SparkSQL Multiple Statements Syntax Suggestion', () => {
         );
 
         expect(suggestion).not.toBeUndefined();
-        expect(suggestion?.wordRanges.map((token) => token.text)).toEqual(['db', '.']);
+        expect(suggestion?.wordRanges?.length).toBe(2);
+        expect(suggestion?.wordRanges).toEqual([
+            {
+                endColumn: 17,
+                endIndex: 258,
+                line: 9,
+                startColumn: 15,
+                startIndex: 257,
+                text: 'db',
+            },
+            {
+                endColumn: 18,
+                endIndex: 259,
+                line: 9,
+                startColumn: 17,
+                startIndex: 259,
+                text: '.',
+            },
+        ]);
     });
 
     test('Insert into table ', () => {

--- a/test/parser/spark/suggestion/syntaxSuggestion.test.ts
+++ b/test/parser/spark/suggestion/syntaxSuggestion.test.ts
@@ -32,7 +32,33 @@ describe('Spark SQL Syntax Suggestion', () => {
         );
 
         expect(suggestion).not.toBeUndefined();
-        expect(suggestion?.wordRanges.map((token) => token.text)).toEqual(['db', '.', 'tb']);
+        expect(suggestion?.wordRanges?.length).toBe(3);
+        expect(suggestion?.wordRanges).toEqual([
+            {
+                text: 'db',
+                line: 1,
+                startIndex: 12,
+                endIndex: 13,
+                startColumn: 13,
+                endColumn: 15,
+            },
+            {
+                text: '.',
+                line: 1,
+                startIndex: 14,
+                endIndex: 14,
+                startColumn: 15,
+                endColumn: 16,
+            },
+            {
+                text: 'tb',
+                line: 1,
+                startIndex: 15,
+                endIndex: 16,
+                startColumn: 16,
+                endColumn: 18,
+            },
+        ]);
     });
 
     test('Select table ', () => {

--- a/test/parser/trino/suggestion/multipleStatement.test.ts
+++ b/test/parser/trino/suggestion/multipleStatement.test.ts
@@ -36,7 +36,25 @@ describe('TrinoSQL Multiple Statements Syntax Suggestion', () => {
         );
 
         expect(suggestion).not.toBeUndefined();
-        expect(suggestion?.wordRanges.map((token) => token.text)).toEqual(['db', '.']);
+        expect(suggestion?.wordRanges?.length).toBe(2);
+        expect(suggestion?.wordRanges).toEqual([
+            {
+                text: 'db',
+                line: 9,
+                startIndex: 137,
+                endIndex: 138,
+                startColumn: 17,
+                endColumn: 19,
+            },
+            {
+                text: '.',
+                line: 9,
+                startIndex: 139,
+                endIndex: 139,
+                startColumn: 19,
+                endColumn: 20,
+            },
+        ]);
     });
 
     test('Insert into table ', () => {

--- a/test/parser/trino/suggestion/syntaxSuggestion.test.ts
+++ b/test/parser/trino/suggestion/syntaxSuggestion.test.ts
@@ -32,7 +32,33 @@ describe('Trino SQL Syntax Suggestion', () => {
             (syn) => syn.syntaxContextType === EntityContextType.TABLE
         );
         expect(suggestion).not.toBeUndefined();
-        expect(suggestion?.wordRanges.map((token) => token.text)).toEqual(['db', '.', 'tb']);
+        expect(suggestion?.wordRanges?.length).toBe(3);
+        expect(suggestion?.wordRanges).toEqual([
+            {
+                text: 'db',
+                line: 1,
+                startIndex: 12,
+                endIndex: 13,
+                startColumn: 13,
+                endColumn: 15,
+            },
+            {
+                text: '.',
+                line: 1,
+                startIndex: 14,
+                endIndex: 14,
+                startColumn: 15,
+                endColumn: 16,
+            },
+            {
+                text: 'tb',
+                line: 1,
+                startIndex: 15,
+                endIndex: 16,
+                startColumn: 16,
+                endColumn: 18,
+            },
+        ]);
     });
 
     test('Select table ', () => {


### PR DESCRIPTION
1. #410 

### 变更内容

提前将 tokenIndexOffset 应用到 allTokens 的集合中，不再需要多层传递。

在 https://github.com/DTStack/dt-sql-parser/pull/334#discussion_r1800582071 有进行讨论。
<img width="970" alt="Google Chrome 2025-04-03 10 40 52" src="https://github.com/user-attachments/assets/db2636dd-4374-4845-a084-9739f5423c12" />