### PR TITLE
fix(trino): add selectItem rule to candidates for column suggestions

### DIFF
--- a/src/parser/trino/index.ts
+++ b/src/parser/trino/index.ts
@@ -136,6 +136,7 @@ export class TrinoSQL extends BasicSQL<TrinoSqlLexer, ProgramContext, TrinoSqlPa
                 }
                 case TrinoSqlParser.RULE_columnName: {
                     if (
+                        candidateRule.ruleList.includes(TrinoSqlParser.RULE_selectItem) ||
                         candidateRule.ruleList.includes(TrinoSqlParser.RULE_groupBy) ||
                         candidateRule.ruleList.includes(TrinoSqlParser.RULE_sortItem) ||
                         candidateRule.ruleList.includes(TrinoSqlParser.RULE_whereClause) ||

--- a/test/parser/trino/suggestion/fixtures/syntaxSuggestion.sql
+++ b/test/parser/trino/suggestion/fixtures/syntaxSuggestion.sql
@@ -61,3 +61,5 @@ SELECT * FROM users CROSS JOIN UNNEST(friends) WITH ordinality;
 SELECT  FROM tb1;
 
 SELECT age FROM tb1;
+
+SELECT a. FROM tb1 a;

--- a/test/parser/trino/suggestion/syntaxSuggestion.test.ts
+++ b/test/parser/trino/suggestion/syntaxSuggestion.test.ts
@@ -598,6 +598,25 @@ describe('Trino SQL Syntax Suggestion', () => {
         ).toEqual([['age'], ['age']]);
     });
 
+    test('Select alias column', () => {
+        const pos: CaretPosition = {
+            lineNumber: 65,
+            column: 10,
+        };
+        const syntaxes = trino.getSuggestionAtCaretPosition(
+            commentOtherLine(syntaxSql, pos.lineNumber),
+            pos
+        )?.syntax;
+
+        const wordRangesArr = syntaxes?.map((syn) => syn.wordRanges);
+
+        expect(wordRangesArr).not.toBeUndefined();
+        expect(wordRangesArr.length).toBe(1);
+        expect(
+            wordRangesArr.map((wordRanges) => wordRanges.map((wordRange) => wordRange.text))
+        ).toEqual([['a', '.']]);
+    });
+
     test('Syntax suggestion after a comment', () => {
         const sql = `-- the comment\nSELECT * FROM db.`;
         const pos: CaretPosition = {


### PR DESCRIPTION
Hi! There is no column suggestions when the name/alias of the table is specified inside the select. Although it works in where and group by clause.

I tried to fix it, please take a look.
