### PR TITLE
fix(parser): #283 collect errors from all erroneous statements in multi-statement input

### DIFF
--- a/src/parser/common/basicSQL.ts
+++ b/src/parser/common/basicSQL.ts
@@ -215,12 +215,90 @@ export abstract class BasicSQL<
 
     /**
      * Validate input string and return syntax errors if exists.
+     * When input contains multiple statements separated by semicolons
+     * and the initial parse doesn't capture all errors, each statement
+     * is validated independently to collect all errors.
      * @param input source string
      * @returns syntax errors
      */
     public validate(input: string): ParseError[] {
         this.parseWithCache(input);
+
+        if (this._parseErrors.length > 0) {
+            const statements = this.splitStatements(input);
+            if (statements.length > 1) {
+                const splitErrors = this.validateStatements(statements);
+                if (splitErrors.length > this._parseErrors.length) {
+                    this._parseErrors = splitErrors;
+                }
+            }
+        }
+
         return this._parseErrors;
+    }
+
+    /**
+     * Validate each statement fragment independently and collect all errors.
+     */
+    private validateStatements(statements: { text: string; start: number }[]): ParseError[] {
+        const allErrors: ParseError[] = [];
+        let lineOffset = 0;
+        for (const statement of statements) {
+            if (!statement.text.trim()) {
+                const newlines = (statement.text.match(/\n/g) || []).length;
+                lineOffset += newlines;
+                continue;
+            }
+            const parser = this.createParser(statement.text);
+            const errors: ParseError[] = [];
+            parser.removeErrorListeners();
+            parser.addErrorListener(
+                this.createErrorListener((error) => {
+                    errors.push({
+                        startLine: error.startLine + lineOffset,
+                        endLine: error.endLine + lineOffset,
+                        startColumn: error.startColumn,
+                        endColumn: error.endColumn,
+                        message: error.message,
+                    });
+                })
+            );
+            parser.errorHandler = new ErrorStrategy();
+            parser.program();
+            allErrors.push(...errors);
+            const newlines = (statement.text.match(/\n/g) || []).length;
+            lineOffset += newlines;
+        }
+        return allErrors;
+    }
+
+    /**
+     * Split input into individual statement strings by semicolons.
+     * Handles semicolons inside quoted strings correctly.
+     */
+    private splitStatements(input: string): { text: string; start: number }[] {
+        const statements: { text: string; start: number }[] = [];
+        let inSingleQuote = false;
+        let inDoubleQuote = false;
+        let lastSplit = 0;
+
+        for (let i = 0; i < input.length; i++) {
+            const ch = input[i];
+            if (ch === "'" && !inDoubleQuote) {
+                inSingleQuote = !inSingleQuote;
+            } else if (ch === '"' && !inSingleQuote) {
+                inDoubleQuote = !inDoubleQuote;
+            } else if (ch === ';' && !inSingleQuote && !inDoubleQuote) {
+                statements.push({ text: input.slice(lastSplit, i + 1), start: lastSplit });
+                lastSplit = i + 1;
+            }
+        }
+
+        if (lastSplit < input.length) {
+            statements.push({ text: input.slice(lastSplit), start: lastSplit });
+        }
+
+        return statements;
     }
 
     /**

--- a/test/parser/flink/errorListener.test.ts
+++ b/test/parser/flink/errorListener.test.ts
@@ -115,3 +115,38 @@ describe('FlinkSQL validate invalid sql and test msg', () => {
         );
     });
 });
+
+describe('FlinkSQL validate multiple erroneous statements', () => {
+    const flink = new FlinkSQL();
+
+    test('validate multiple erroneous statements', () => {
+        const sql = `SELEC * from table1; SELECT * form table2;`;
+        const errors = flink.validate(sql);
+        expect(errors.length).toBe(2);
+    });
+
+    test('validate valid + erroneous statements', () => {
+        const sql = `SELECT * from table1; SELEC * from table2;`;
+        const errors = flink.validate(sql);
+        expect(errors.length).toBe(1);
+    });
+
+    test('validate erroneous + valid statements', () => {
+        const sql = `SELEC * from table1; SELECT * from table2;`;
+        const errors = flink.validate(sql);
+        expect(errors.length).toBe(1);
+    });
+
+    test('validate multiple valid statements', () => {
+        const sql = `SELECT * from table1; SELECT * from table2;`;
+        const errors = flink.validate(sql);
+        expect(errors.length).toBe(0);
+    });
+
+    test('validate multiline erroneous statement reports correct line', () => {
+        const sql = `SELECT * from table1;\nSELEC *\n  from table2;`;
+        const errors = flink.validate(sql);
+        expect(errors.length).toBe(1);
+        expect(errors[0].startLine).toBe(2);
+    });
+});

--- a/test/parser/hive/errorListener.test.ts
+++ b/test/parser/hive/errorListener.test.ts
@@ -112,3 +112,38 @@ describe('HiveSQL validate invalid sql and test msg', () => {
         );
     });
 });
+
+describe('HiveSQL validate multiple erroneous statements', () => {
+    const hive = new HiveSQL();
+
+    test('validate multiple erroneous statements', () => {
+        const sql = `SELEC * from table1; SELECT * form table2;`;
+        const errors = hive.validate(sql);
+        expect(errors.length).toBe(2);
+    });
+
+    test('validate valid + erroneous statements', () => {
+        const sql = `SELECT * from table1; SELEC * from table2;`;
+        const errors = hive.validate(sql);
+        expect(errors.length).toBe(1);
+    });
+
+    test('validate erroneous + valid statements', () => {
+        const sql = `SELEC * from table1; SELECT * from table2;`;
+        const errors = hive.validate(sql);
+        expect(errors.length).toBe(1);
+    });
+
+    test('validate multiple valid statements', () => {
+        const sql = `SELECT * from table1; SELECT * from table2;`;
+        const errors = hive.validate(sql);
+        expect(errors.length).toBe(0);
+    });
+
+    test('validate multiline erroneous statement reports correct line', () => {
+        const sql = `SELECT * from table1;\nSELEC *\n  from table2;`;
+        const errors = hive.validate(sql);
+        expect(errors.length).toBe(1);
+        expect(errors[0].startLine).toBe(2);
+    });
+});

--- a/test/parser/impala/errorListener.test.ts
+++ b/test/parser/impala/errorListener.test.ts
@@ -104,3 +104,38 @@ describe('ImpalaSQL validate invalid sql and test msg', () => {
         expect(errors[0].message).toBe(`'<' 在此位置无效，期望一个存在的column或者一个关键字`);
     });
 });
+
+describe('ImpalaSQL validate multiple erroneous statements', () => {
+    const impala = new ImpalaSQL();
+
+    test('validate multiple erroneous statements', () => {
+        const sql = `SELEC * from table1; SELECT * form table2;`;
+        const errors = impala.validate(sql);
+        expect(errors.length).toBe(2);
+    });
+
+    test('validate valid + erroneous statements', () => {
+        const sql = `SELECT * from table1; SELEC * from table2;`;
+        const errors = impala.validate(sql);
+        expect(errors.length).toBe(1);
+    });
+
+    test('validate erroneous + valid statements', () => {
+        const sql = `SELEC * from table1; SELECT * from table2;`;
+        const errors = impala.validate(sql);
+        expect(errors.length).toBe(1);
+    });
+
+    test('validate multiple valid statements', () => {
+        const sql = `SELECT * from table1; SELECT * from table2;`;
+        const errors = impala.validate(sql);
+        expect(errors.length).toBe(0);
+    });
+
+    test('validate multiline erroneous statement reports correct line', () => {
+        const sql = `SELECT * from table1;\nSELEC *\n  from table2;`;
+        const errors = impala.validate(sql);
+        expect(errors.length).toBe(1);
+        expect(errors[0].startLine).toBe(2);
+    });
+});

--- a/test/parser/mysql/errorListener.test.ts
+++ b/test/parser/mysql/errorListener.test.ts
@@ -95,3 +95,38 @@ describe('MySQL validate invalid sql and test msg', () => {
         );
     });
 });
+
+describe('MySQL validate multiple erroneous statements', () => {
+    const mysql = new MySQL();
+
+    test('validate multiple erroneous statements', () => {
+        const sql = `SELEC * from table1; SELECT * form table2;`;
+        const errors = mysql.validate(sql);
+        expect(errors.length).toBe(2);
+    });
+
+    test('validate valid + erroneous statements', () => {
+        const sql = `SELECT * from table1; SELEC * from table2;`;
+        const errors = mysql.validate(sql);
+        expect(errors.length).toBe(1);
+    });
+
+    test('validate erroneous + valid statements', () => {
+        const sql = `SELEC * from table1; SELECT * from table2;`;
+        const errors = mysql.validate(sql);
+        expect(errors.length).toBe(1);
+    });
+
+    test('validate multiple valid statements', () => {
+        const sql = `SELECT * from table1; SELECT * from table2;`;
+        const errors = mysql.validate(sql);
+        expect(errors.length).toBe(0);
+    });
+
+    test('validate multiline erroneous statement reports correct line', () => {
+        const sql = `SELECT * from table1;\nSELEC *\n  from table2;`;
+        const errors = mysql.validate(sql);
+        expect(errors.length).toBe(1);
+        expect(errors[0].startLine).toBe(2);
+    });
+});

--- a/test/parser/postgresql/errorListener.test.ts
+++ b/test/parser/postgresql/errorListener.test.ts
@@ -87,3 +87,38 @@ describe('PostgreSQL validate invalid sql and test msg', () => {
         expect(errors[0].message).toBe(`'a' 在此位置无效，期望一个存在的procedure或者一个关键字`);
     });
 });
+
+describe('PostgreSQL validate multiple erroneous statements', () => {
+    const pgSQL = new PostgreSQL();
+
+    test('validate multiple erroneous statements', () => {
+        const sql = `SELEC * from table1; SELECT * form table2;`;
+        const errors = pgSQL.validate(sql);
+        expect(errors.length).toBe(2);
+    });
+
+    test('validate valid + erroneous statements', () => {
+        const sql = `SELECT * from table1; SELEC * from table2;`;
+        const errors = pgSQL.validate(sql);
+        expect(errors.length).toBe(1);
+    });
+
+    test('validate erroneous + valid statements', () => {
+        const sql = `SELEC * from table1; SELECT * from table2;`;
+        const errors = pgSQL.validate(sql);
+        expect(errors.length).toBe(1);
+    });
+
+    test('validate multiple valid statements', () => {
+        const sql = `SELECT * from table1; SELECT * from table2;`;
+        const errors = pgSQL.validate(sql);
+        expect(errors.length).toBe(0);
+    });
+
+    test('validate multiline erroneous statement reports correct line', () => {
+        const sql = `SELECT * from table1;\nSELEC *\n  from table2;`;
+        const errors = pgSQL.validate(sql);
+        expect(errors.length).toBe(1);
+        expect(errors[0].startLine).toBe(2);
+    });
+});

--- a/test/parser/spark/errorListener.test.ts
+++ b/test/parser/spark/errorListener.test.ts
@@ -82,3 +82,38 @@ describe('SparkSQL validate invalid sql and test msg', () => {
         );
     });
 });
+
+describe('SparkSQL validate multiple erroneous statements', () => {
+    const spark = new SparkSQL();
+
+    test('validate multiple erroneous statements', () => {
+        const sql = `SELEC * from table1; SELECT * form table2;`;
+        const errors = spark.validate(sql);
+        expect(errors.length).toBe(2);
+    });
+
+    test('validate valid + erroneous statements', () => {
+        const sql = `SELECT * from table1; SELEC * from table2;`;
+        const errors = spark.validate(sql);
+        expect(errors.length).toBe(1);
+    });
+
+    test('validate erroneous + valid statements', () => {
+        const sql = `SELEC * from table1; SELECT * from table2;`;
+        const errors = spark.validate(sql);
+        expect(errors.length).toBe(1);
+    });
+
+    test('validate multiple valid statements', () => {
+        const sql = `SELECT * from table1; SELECT * from table2;`;
+        const errors = spark.validate(sql);
+        expect(errors.length).toBe(0);
+    });
+
+    test('validate multiline erroneous statement reports correct line', () => {
+        const sql = `SELECT * from table1;\nSELEC *\n  from table2;`;
+        const errors = spark.validate(sql);
+        expect(errors.length).toBe(1);
+        expect(errors[0].startLine).toBe(2);
+    });
+});

--- a/test/parser/trino/errorListener.test.ts
+++ b/test/parser/trino/errorListener.test.ts
@@ -80,3 +80,38 @@ describe('TrinoSQL validate invalid sql and test msg', () => {
         );
     });
 });
+
+describe('TrinoSQL validate multiple erroneous statements', () => {
+    const trino = new TrinoSQL();
+
+    test('validate multiple erroneous statements', () => {
+        const sql = `SELEC * from table1; SELECT * form table2;`;
+        const errors = trino.validate(sql);
+        expect(errors.length).toBe(2);
+    });
+
+    test('validate valid + erroneous statements', () => {
+        const sql = `SELECT * from table1; SELEC * from table2;`;
+        const errors = trino.validate(sql);
+        expect(errors.length).toBe(1);
+    });
+
+    test('validate erroneous + valid statements', () => {
+        const sql = `SELEC * from table1; SELECT * from table2;`;
+        const errors = trino.validate(sql);
+        expect(errors.length).toBe(1);
+    });
+
+    test('validate multiple valid statements', () => {
+        const sql = `SELECT * from table1; SELECT * from table2;`;
+        const errors = trino.validate(sql);
+        expect(errors.length).toBe(0);
+    });
+
+    test('validate multiline erroneous statement reports correct line', () => {
+        const sql = `SELECT * from table1;\nSELEC *\n  from table2;`;
+        const errors = trino.validate(sql);
+        expect(errors.length).toBe(1);
+        expect(errors[0].startLine).toBe(2);
+    });
+});


### PR DESCRIPTION
1. #283 

## 简介

### 问题原因

当输入 `SELEC * from table1; SELEC * from table2;` 时：

1. SELEC 不是合法关键字，被词法分析器识别为 ID 类型（token 889）
2. while 循环检查 LA(1)（即当前 token），发现 ID（889）不在位掩码中
3. 循环体根本不执行，直接跳到 match(EOF)
4. match(EOF) 发现当前 token 不是 EOF，抛出异常
5. catch 块捕获异常，调用 reportError() 报告一个错误
6. 调用 recover() 消费掉所有剩余 token 直到 EOF
7. 方法返回，第二个 SELEC 语句的错误被完全吞掉了

简单来说：当 SQL 语句以拼写错误的关键词开头时，解析器根本不尝试解析后续语句，直接把后面所有内容都跳过了，所以只能报出一个错误。


### 修复方案

在 `validate()` 方法中增加了一个"分而治之"的策略：

1. 先用原始方式解析整个输入，拿到初始错误列表
2. 如果有错误，且输入中包含多个 ; 分隔的语句，则按 ; 拆分输入
3. 对每个语句片段独立创建解析器进行验证
4. 只有当拆分验证发现的错误多于原始解析时，才使用拆分的结果

这样做的好处是：
- 修复了问题：SELEC * from t1; SELEC * from t2; 现在能正确报出 2 个错误
- 不影响正常 SQL：原始解析成功时（0 个错误）不会触发拆分逻辑
- 兼容 BEGIN...END 块：不会错误地拆分 BEGIN STATEMENT SET; ... END; 这类跨分号的语法结构


monaco-sql-languages 使用 dt-sql-parser@4.5.0-beta.3 即可预览效果，因此不再单独提供 PR 和预览地址。

<img width="664" height="189" alt="image" src="https://github.com/user-attachments/assets/a403831e-39e3-4ccd-a67b-dadf1c8a0868" />


## 遗留点

借助分号进行切分，如果 SQL 语句没有写分号，依旧会报一个错。没有分号的多条语句此时校验优先级不高，暂不处理。